### PR TITLE
Manage composite primary key

### DIFF
--- a/lib/chrono_model/adapter.rb
+++ b/lib/chrono_model/adapter.rb
@@ -24,6 +24,17 @@ module ChronoModel
     def chrono_supported?
       postgresql_version >= 90300
     end
+    
+    # Enable to manage an array of column names (added for composite-primary-keys)
+    def quote_column_name(name)
+      if name.is_a?(Array)
+        Array(name).map do |col|
+          super(col.to_s)
+        end.join(',')
+      else
+        super
+      end
+    end
 
     # Creates the given table, possibly creating the temporal schema
     # objects if the `:temporal` option is given and set to true.


### PR DESCRIPTION
Overriding of ActiveRecord method "quote_column_name" to manage multiple column names. When the project integrate the gem "composite-primary-keys" [1], the returned primary key is an array. (refs #13)

[1] https://github.com/composite-primary-keys/composite_primary_keys
