### PR TITLE
Fixes

### DIFF
--- a/lib/chrono_model/adapter.rb
+++ b/lib/chrono_model/adapter.rb
@@ -285,7 +285,19 @@ module ChronoModel
       chrono_alter(table_name) { super }
     end
 
-    # Runs column_definitions, primary_key and indexes in the temporal schema,
+    # Runs column_definitions in the temporal schema, as the table there
+    # defined is the source for this information.
+    #
+    # The default search path is included however, since the table
+    # may reference types defined in other schemas, which result in their
+    # names becoming schema qualified, which will cause type resolutions to fail.
+    #
+    define_method(:column_definitions) do |table_name|
+      return super(table_name) unless is_chrono?(table_name)
+      on_schema(TEMPORAL_SCHEMA + ',' + self.schema_search_path, false) { super(table_name) }
+    end
+
+    # Runs primary_key and indexes in the temporal schema,
     # as the table there defined is the source for this information.
     #
     # Moreover, the PostgreSQLAdapter +indexes+ method uses current_schema(),
@@ -294,7 +306,7 @@ module ChronoModel
     # Schema nesting is disabled on these calls, make sure to fetch metadata
     # from the first caller's selected schema and not from the current one.
     #
-    [:column_definitions, :primary_key, :indexes].each do |method|
+    [:primary_key, :indexes].each do |method|
       define_method(method) do |table_name|
         return super(table_name) unless is_chrono?(table_name)
         _on_temporal_schema(false) { super(table_name) }

--- a/lib/chrono_model/adapter.rb
+++ b/lib/chrono_model/adapter.rb
@@ -297,7 +297,7 @@ module ChronoModel
       on_schema(TEMPORAL_SCHEMA + ',' + self.schema_search_path, false) { super(table_name) }
     end
 
-    # Runs primary_key and indexes in the temporal schema,
+    # Runs primary_key, indexes and default_sequence_name in the temporal schema,
     # as the table there defined is the source for this information.
     #
     # Moreover, the PostgreSQLAdapter +indexes+ method uses current_schema(),
@@ -306,10 +306,11 @@ module ChronoModel
     # Schema nesting is disabled on these calls, make sure to fetch metadata
     # from the first caller's selected schema and not from the current one.
     #
-    [:primary_key, :indexes].each do |method|
-      define_method(method) do |table_name|
-        return super(table_name) unless is_chrono?(table_name)
-        _on_temporal_schema(false) { super(table_name) }
+    [:primary_key, :indexes, :default_sequence_name].each do |method|
+      define_method(method) do |*args|
+        table_name = args.first
+        return super(*args) unless is_chrono?(table_name)
+        _on_temporal_schema(false) { super(*args) }
       end
     end
 

--- a/lib/chrono_model/schema_format.rake
+++ b/lib/chrono_model/schema_format.rake
@@ -27,8 +27,16 @@ namespace :db do
         f.puts "SET search_path TO #{ActiveRecord::Base.connection.schema_search_path};\n\n"
         f.puts ActiveRecord::Base.connection.dump_schema_information
       end
-    end
 
+      # the structure.sql file will contain CREATE SCHEMA statements
+      # but chronomodel creates the temporal and history schemas
+      # when the connection is established, so a db:structure:load fails
+      # fix up create schema statements to include the IF NOT EXISTS directive
+
+      sql = File.read(target)
+      sql.gsub!(/CREATE SCHEMA /, 'CREATE SCHEMA IF NOT EXISTS ')
+      File.open(target, "w") { |file| file << sql  }
+    end
 
     desc "Load structure.sql file into the current environment's database"
     task :load => :environment do

--- a/lib/chrono_model/schema_format.rake
+++ b/lib/chrono_model/schema_format.rake
@@ -1,4 +1,3 @@
-require 'shellwords'
 load File.expand_path(File.dirname(__FILE__) + '/schema_format.rb')
 
 namespace :db do
@@ -15,7 +14,7 @@ namespace :db do
         schema_search_path << ",#{ChronoModel::Adapter::HISTORY_SCHEMA}"
 
         # convert to command line arguments
-        schema_search_path = schema_search_path.split(",").map{|part| "--schema=#{Shellwords.escape(part.strip)}" }.join(" ")
+        schema_search_path = schema_search_path.split(",").map{|part| "--schema=#{part.strip}" }.join(" ")
       end
 
       PG.make_dump target,

--- a/lib/chrono_model/schema_format.rb
+++ b/lib/chrono_model/schema_format.rb
@@ -24,6 +24,7 @@ module PG
       ENV['PGHOST']     = config[:host].to_s     if config.key?(:host)
       ENV['PGPORT']     = config[:port].to_s     if config.key?(:port)
       ENV['PGPASSWORD'] = config[:password].to_s if config.key?(:password)
+      ENV['PGUSER']     = config[:username].to_s if config.key?(:username)
     end
   end
 

--- a/lib/chrono_model/schema_format.rb
+++ b/lib/chrono_model/schema_format.rb
@@ -29,7 +29,7 @@ module PG
   end
 
   def make_dump(target, username, database, *options)
-    exec 'pg_dump', '-f', target, '-U', username, database, *options
+    exec 'pg_dump', '-f', target, '-U', username, '-d', database, *options
   end
 
   def load_dump(source, username, database, *options)


### PR DESCRIPTION
* Schema search paths
* `CREATE SCHEMA` statements when using `rake db:structure:load`
* Resolution of types which are schema qualified when creating tables on the temporal schema. E.g. hstore
* Fix for when using `:sql` format and `pg_dump` command
* Fix for `default_sequence_name` method
