### PR TITLE
set recorded_at together with validity in amend_period!

### DIFF
--- a/lib/chrono_model/utils.rb
+++ b/lib/chrono_model/utils.rb
@@ -51,7 +51,8 @@ module ChronoModel
 
       connection.execute %[
         UPDATE #{quoted_table_name}
-           SET "validity" = tsrange(#{connection.quote(from)}, #{connection.quote(to)})
+           SET "validity" = tsrange(#{connection.quote(from)}, #{connection.quote(to)}),
+               "recorded_at" = #{connection.quote(from)}
          WHERE "hid" = #{hid.to_i}
       ]
     end


### PR DESCRIPTION
I think that `recorded_at` needs to be changed together with validity, because it's used for sorting purposes, and so impacting `first` and `last` methods invoked on `some_record.history`.

See here:
https://github.com/ifad/chronomodel/blob/master/lib/chrono_model/time_machine.rb#L57
and here:
https://github.com/ifad/chronomodel/blob/master/lib/chrono_model/time_machine.rb#L502-L504