### PR TITLE
Force AR to be < 5.1.0

### DIFF
--- a/chrono_model.gemspec
+++ b/chrono_model.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = ChronoModel::VERSION
 
-  gem.add_dependency "activerecord", ">= 4.2.0"
+  gem.add_dependency 'activerecord', '>= 4.2.0', '< 5.1.0'
   gem.add_dependency "pg"
   gem.add_dependency "multi_json"
 


### PR DESCRIPTION
`activerecord` >= 5.1.0 makes some tests fail because it represents id columns as Bigint rather than as Integer