### PR TITLE
Handle strings without fractions of seconds

### DIFF
--- a/lib/chrono_model/utils.rb
+++ b/lib/chrono_model/utils.rb
@@ -7,7 +7,7 @@ module ChronoModel
 
     def string_to_utc_time(string)
       if string =~ ISO_DATETIME
-        usec = $7.nil? ? '0'*6 : $7.ljust(6, '0') # .1 is .100000, not .000001
+        usec = $7.nil? ? '000000' : $7.ljust(6, '0') # .1 is .100000, not .000001
         Time.utc $1.to_i, $2.to_i, $3.to_i, $4.to_i, $5.to_i, $6.to_i, usec.to_i
       end
     end

--- a/lib/chrono_model/utils.rb
+++ b/lib/chrono_model/utils.rb
@@ -7,7 +7,7 @@ module ChronoModel
 
     def string_to_utc_time(string)
       if string =~ ISO_DATETIME
-        usec = $7.ljust(6, '0') # .1 is .100000, not .000001
+        usec = $7.nil? ? '0'*6 : $7.ljust(6, '0') # .1 is .100000, not .000001
         Time.utc $1.to_i, $2.to_i, $3.to_i, $4.to_i, $5.to_i, $6.to_i, usec.to_i
       end
     end


### PR DESCRIPTION
Sometimes `from` or `to` components of `validity` field in history records are altered manually (e.g. for testing purpose or to create seed/demo data). Validity ranges could be set from utc time objects created like this:
`Time.utc(2014, 11, 19)`
that would be written on the database without fractions of seconds:
`2014-11-19 00:00:00`

This tiny PR makes `ChronoModel::Conversions#string_to_utc_time` more robust so that it can handle timestamps that don't have fractions of seconds.