### PR TITLE
Add section Testing to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,12 @@ offers many more indexing abilities and better performance than JSON.
  4. Push to the branch (`git push origin my-new-feature`)
  5. Create new Pull Request
 
+## Testing
+
+1. Run `bundle install`
+2. Run `cp spec/database.yml.example spec/database.yml`
+3. Adjust `spec/database.yml` to your needs
+4. Run `bundle exec rspec`
 
 ## Special mention
 


### PR DESCRIPTION
A testing section in the README encourages people to write tests, shows
that tests exist after all and may save 30 seconds to search for the
database.yml.example


# Unrelated to this PR

I tried to set up some tests for https://github.com/ifad/chronomodel/issues/55. The problem is, that we need a different `database.yml`. Apparently, the `dump` and `load` rake tasks of the schema are out of scope of the current test suite.

Actuallly, a proper way to create tests for the recent issues would be to set up a minimal rails environment and test the behaviour of `chronomodel` with an acceptance test.
I was about to do exactly this with [`aruba`](https://github.com/cucumber/aruba). But that would require some additional setup of the build server and the test procedure. Can sb. give me feedback, if that's a good idea or not?