### PR TITLE
expose #56

### DIFF
--- a/spec/aruba/fixtures/migrations/56/20160812190335_create_impressions.rb
+++ b/spec/aruba/fixtures/migrations/56/20160812190335_create_impressions.rb
@@ -1,0 +1,10 @@
+class CreateImpressions < ActiveRecord::Migration[5.0]
+  def change
+    create_table :impressions do |t|
+      t.integer :response
+      t.decimal :amount
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/aruba/fixtures/migrations/56/20171115195229_add_temporal_extension_to_impressions.rb
+++ b/spec/aruba/fixtures/migrations/56/20171115195229_add_temporal_extension_to_impressions.rb
@@ -1,0 +1,10 @@
+class AddTemporalExtensionToImpressions < ActiveRecord::Migration[5.1]
+  def self.up
+    enable_extension 'btree_gist' unless extension_enabled?('btree_gist')
+    change_table :impressions, temporal: true, copy_data: true
+  end
+
+  def self.down
+    change_table :impressions, temporal: false
+  end
+end

--- a/spec/aruba/migrations_spec.rb
+++ b/spec/aruba/migrations_spec.rb
@@ -1,18 +1,48 @@
 require 'spec_helper'
 
-describe 'database migrations' do
+describe 'database migrations', type: :aruba do
   context 'after a migration was generated' do
     before { write_file('config/database.yml',
       File.read(File.expand_path('fixtures/database_without_username_and_password.yml', __dir__))) }
 
     before { run_simple('bundle exec rails g migration CreateModels name:string') }
 
-    describe 'bundle exec rake db:migrate', type: :aruba do
+    describe 'bundle exec rake db:migrate' do
       let(:action) { run('bundle exec rake db:migrate') }
       let(:last_command) { action && last_command_started }
 
       specify { expect(last_command).to be_successfully_executed }
       specify { expect(last_command).to have_output(/CreateModels: migrated/) }
+    end
+  end
+
+
+  describe 'rerun bundle exec rake db:drop db:create db:migrate', :announce_stdout, :announce_stderr, issue: 56 do
+    let(:command) { 'bundle exec rake db:drop db:create db:migrate' }
+    before do
+      copy(
+        '../../spec/aruba/fixtures/database_without_username_and_password.yml',
+        'config/database.yml'
+      )
+      copy(
+        '../../spec/aruba/fixtures/migrations/56/',
+        'db/migrate'
+      )
+    end
+
+    let(:action) { run(command) }
+    let(:regex) { /-- change_table\(:impressions, {:temporal=>true, :copy_data=>true}\)/ }
+
+    describe 'once' do
+      let(:last_command) { action && last_command_started }
+      specify { expect(last_command).to be_successfully_executed }
+      specify { expect(last_command).to have_output(regex) }
+    end
+
+    describe 'twice' do
+      let(:last_command) { run_simple(command) && action && last_command_started }
+      specify { expect(last_command).to be_successfully_executed }
+      specify { expect(last_command).to have_output(regex) }
     end
   end
 end


### PR DESCRIPTION
There you go. I think setting up `aruba` was worth it. Just exposing #56 took me an hour, which I think is good!


The fixture migrations are a subset of our migrations.

I don't have a clue yet, why this error can exist (I mean we're dropping the entire database, right?) But it's reproducable :tada: :smile_cat: 

Maybe because postgres writes into a maintenance database when we migrate views etc? :confused: 