### PR TITLE
Rails > 5.1 exception fix

### DIFF
--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -2,5 +2,6 @@ source "https://rubygems.org"
 
 gem "activerecord", "~> 4.2.0"
 gem "rails", "~> 4.2.0"
+gem "pg", "~> 0.18"
 
 gemspec :path => "../"

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -2,5 +2,6 @@ source "https://rubygems.org"
 
 gem "activerecord", "~> 5.0.0"
 gem "rails", "~> 5.0.0"
+gem "pg", "~> 0.18"
 
 gemspec :path => "../"

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -2,5 +2,6 @@ source "https://rubygems.org"
 
 gem "activerecord", "~> 5.1.0"
 gem "rails", "~> 5.1.0"
+gem "pg", "~> 0.18"
 
 gemspec :path => "../"

--- a/lib/chrono_model/adapter.rb
+++ b/lib/chrono_model/adapter.rb
@@ -914,7 +914,7 @@ module ChronoModel
 
       def translate_exception(exception, message)
         if exception.message =~ /conflicting key value violates exclusion constraint/
-          ActiveRecord::RecordNotUnique.new(message, exception)
+          ActiveRecord::RecordNotUnique.new(message)
         else
           super
         end


### PR DESCRIPTION
Fixes #67 . The second parameter was deprecated and optional for a long time.

https://github.com/rails/rails/blob/v5.0.6/activerecord/lib/active_record/errors.rb#L100-L104