### PR TITLE
v0.12.2: Fix nil pointer error when {:as_of_time => nil}

### DIFF
--- a/lib/chrono_model/patches.rb
+++ b/lib/chrono_model/patches.rb
@@ -141,7 +141,7 @@ module ChronoModel
       # so we use it directly.
       #
       def preload(records, associations, given_preload_scope = nil)
-        if options.key?(:as_of_time)
+        if options[:as_of_time]
           preload_scope = given_preload_scope || NULL_RELATION.dup
           preload_scope.as_of_time!(options[:as_of_time])
         end
@@ -157,7 +157,7 @@ module ChronoModel
         def build_scope
           scope = super
 
-          if preload_scope.respond_to?(:as_of_time)
+          if preload_scope.respond_to?(:as_of_time) && preload_scope.as_of_time
             scope = scope.as_of(preload_scope.as_of_time)
           end
 

--- a/spec/time_machine_spec.rb
+++ b/spec/time_machine_spec.rb
@@ -684,6 +684,13 @@ describe ChronoModel::TimeMachine do
     end
   end
 
+  describe '#preload' do
+    context 'as_of_time => nil'  do
+      subject { Foo.where(id: 42).preload(:translations) }
+      it { expect{ subject.to_a }.not_to raise_error } 
+    end
+  end
+
   # This group is below here to not to disturb the flow of the above specs.
   #
   context 'history modification' do


### PR DESCRIPTION
I'm pretty sure this is a bug of `chrono_model` but I still don't understand why and therefore I am not able to create test that exposes the bug.

I get a lot of nil pointer errors when I run tests with the new version `0.12.2`. These tests pass if I downgrade to `0.12.1`. The errors are reproducible e.g. when I run `MyModel.order(:name).to_a`. The `name` attribute of `MyModel` is translated with [globalize](https://github.com/globalize/globalize) (creates joins when you order by name). So I assume, we have a strange bug that happens on scopes when you have unrelated joins with other tables.

[Build server.](https://travis-ci.org/roschaefer/rundfunk-mitbestimmen/builds/375577411)