### PR TITLE
Add ruby 2.5 to the travis rvm range

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ rvm:
   - 2.2.7
   - 2.3
   - 2.4
+  - 2.5
 
 gemfile:
   - gemfiles/rails_4.2.gemfile


### PR DESCRIPTION
This adds testing of ruby 2.5 to Travis.