### PR TITLE
Fix upgrade method

### DIFF
--- a/lib/chrono_model.rb
+++ b/lib/chrono_model.rb
@@ -20,7 +20,7 @@ module ChronoModel
       raise ChronoModel::Error, "This database connection is not a ChronoModel::Adapter"
     end
 
-    connection.chrono_upgrade!
+    connection.send :chrono_upgrade!
   end
 
   # Returns an Hash keyed by table name of ChronoModels.


### PR DESCRIPTION
Fixes
```
StandardError: An error has occurred, this and all later migrations canceled:

private method `chrono_upgrade!' called for #<ChronoModel::Adapter:0x00007f8767283cf0>
```