### PR TITLE
Tweak how options[:temporal] is handled

### DIFF
--- a/lib/chrono_model/adapter/migrations.rb
+++ b/lib/chrono_model/adapter/migrations.rb
@@ -79,11 +79,15 @@ module ChronoModel
               super table_name, options, &block
             end
 
-          else
-            if is_chrono?(table_name)
-              chrono_undo_temporal_table(table_name)
-            end
+          elsif options[:temporal] == false && is_chrono?(table_name)
+            chrono_undo_temporal_table(table_name)
 
+            super table_name, options, &block
+          elsif is_chrono?(table_name)
+            drop_and_recreate_public_view(table_name, options) do
+              super table_name, options, &block
+            end
+          else
             super table_name, options, &block
           end
 
@@ -149,6 +153,7 @@ module ChronoModel
       # the temporal schema and update the triggers.
       #
       def rename_column(table_name, *)
+        puts "Entering 'rename column'"
         return super unless is_chrono?(table_name)
 
         # Rename the column in the temporal table and in the view


### PR DESCRIPTION
I still need to write specs for this, but it changes how `options[:temporal]` is handled so that if you don't pass anything explicit it'll work fine (rather than right now, where if you don't specify `temporal: true` on a chronomodel-handled table it'll return it to a plain table).