### PR TITLE
Better check for whether or not a table is_chrono?

### DIFF
--- a/lib/chrono_model/adapter.rb
+++ b/lib/chrono_model/adapter.rb
@@ -133,8 +133,8 @@ module ChronoModel
     # Returns true if the given name references a temporal table.
     #
     def is_chrono?(table)
-      on_temporal_schema { data_source_exists?(table) } &&
-        on_history_schema { data_source_exists?(table) }
+      data_source_exists?("#{TEMPORAL_SCHEMA}.#{quote_table_name(table)}") &&
+        data_source_exists?("#{HISTORY_SCHEMA}.#{quote_table_name(table)}")
     end
 
     # Reads the Gem metadata from the COMMENT set on the given PostgreSQL


### PR DESCRIPTION
The previous check didn't work properly because `data_source_sql` (which `data_source_exists?` uses internally) only qualifies the table_name to the current schema if a fully qualified name isn't passed.

This could be made even better if the schema was stripped off `table` before it's passed in, as
right now this won't work if you pass a fully qualified name in to `change_table` and also pass `temporal: true`

Ref: https://apidock.com/rails/v5.1.7/ActiveRecord/ConnectionAdapters/PostgreSQL/SchemaStatements/data_source_sql and https://apidock.com/rails/v5.1.7/ActiveRecord/ConnectionAdapters/PostgreSQL/SchemaStatements/quoted_scope