### PR TITLE
Do not test Rails 5.2 against Ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ jobs:
       gemfile: gemfiles/rails_5.0.gemfile
     - rvm: 2.7
       gemfile: gemfiles/rails_5.1.gemfile
+    - rvm: 2.7
+      gemfile: gemfiles/rails_5.2.gemfile
 
 addons:
   code_climate:


### PR DESCRIPTION
Rails 5.2 does not officially support Ruby 2.7. This commit excludes the
related build from the matrix

Ref: rails/rails#38426