### PR TITLE
Feature/ruby 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rvm:
   - 2.5
   - 2.6
   - 2.7
+  - 3.0
 
 gemfile:
   - gemfiles/rails_5.0.gemfile
@@ -31,6 +32,12 @@ jobs:
     - rvm: 2.7
       gemfile: gemfiles/rails_5.1.gemfile
     - rvm: 2.7
+      gemfile: gemfiles/rails_5.2.gemfile
+    - rvm: 3.0
+      gemfile: gemfiles/rails_5.0.gemfile
+    - rvm: 3.0
+      gemfile: gemfiles/rails_5.1.gemfile
+    - rvm: 3.0
       gemfile: gemfiles/rails_5.2.gemfile
 
 addons:

--- a/lib/chrono_model/adapter/migrations.rb
+++ b/lib/chrono_model/adapter/migrations.rb
@@ -5,7 +5,7 @@ module ChronoModel
       # Creates the given table, possibly creating the temporal schema
       # objects if the `:temporal` option is given and set to true.
       #
-      def create_table(table_name, options = {})
+      def create_table(table_name, **options)
         # No temporal features requested, skip
         return super unless options[:temporal]
 
@@ -63,7 +63,7 @@ module ChronoModel
       # features on the given table. Please note that you'll lose your history
       # when demoting a temporal table to a plain one.
       #
-      def change_table(table_name, options = {}, &block)
+      def change_table(table_name, **options, &block)
         transaction do
 
           # Add an empty proc to support calling change_table without a block.
@@ -76,7 +76,7 @@ module ChronoModel
             end
 
             drop_and_recreate_public_view(table_name, options) do
-              super table_name, options, &block
+              super table_name, **options, &block
             end
 
           else
@@ -84,7 +84,7 @@ module ChronoModel
               chrono_undo_temporal_table(table_name)
             end
 
-            super table_name, options, &block
+            super table_name, **options, &block
           end
 
         end


### PR DESCRIPTION
TODO:

- [x] Check the `comment:` option (rails/rails@b04c6339640d87b680f1975f3686fed0d885b1bc)
 
Matches signatures from AR 5.0 to 6.0, except 5.x who also uses `comment: nil`

Double splats arguments when calling `super` to provide Ruby 3.0 compatibility

Ref:
- https://github.com/rails/rails/blob/v5.0.0/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb#L262
- https://github.com/rails/rails/blob/v5.1.0/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb#L267
- https://github.com/rails/rails/blob/v5.2.0/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb#L290
- https://github.com/rails/rails/blob/v6.0.0/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb#L294
