### PR TITLE
ActiveRecord 6.1 compatibility

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -27,13 +27,17 @@ jobs:
     strategy:
       matrix:
         ruby-version: ['2.3', '2.4', '2.5', '2.6', '2.7', '3.0']
-        gemfile: [ rails_5.0, rails_5.1, rails_5.2, rails_6.0 ]
+        gemfile: [ rails_5.0, rails_5.1, rails_5.2, rails_6.0, rails_6.1 ]
 
         exclude:
           - ruby-version: '2.3'
             gemfile: rails_6.0
+          - ruby-version: '2.3'
+            gemfile: rails_6.1
           - ruby-version: '2.4'
             gemfile: rails_6.0
+          - ruby-version: '2.4'
+            gemfile: rails_6.1
           - ruby-version: '2.6'
             gemfile: rails_5.0
           - ruby-version: '2.6'

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -28,6 +28,7 @@ jobs:
       matrix:
         ruby-version: ['2.3', '2.4', '2.5', '2.6', '2.7', '3.0']
         gemfile: [ rails_5.0, rails_5.1, rails_5.2, rails_6.0, rails_6.1 ]
+        experimental: [false]
 
         exclude:
           - ruby-version: '2.3'
@@ -58,6 +59,8 @@ jobs:
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
       TEST_CONFIG: ./spec/config.github.yml
+
+    continue-on-error: ${{ matrix.experimental }}
 
     steps:
     - uses: actions/checkout@v2

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "activerecord", "~> 6.1.0"
+gem "rails", "~> 6.1.0"
+
+gemspec :path => "../"

--- a/lib/active_record/tasks/chronomodel_database_tasks.rb
+++ b/lib/active_record/tasks/chronomodel_database_tasks.rb
@@ -41,6 +41,12 @@ module ActiveRecord
 
       private
 
+      def configuration
+        # In Rails 6.1.x the configuration instance variable is not available
+        # and it's been replaced by @configuration_hash (which is frozen).
+        @configuration ||= @configuration_hash.dup
+      end
+
       # If a schema search path is defined in the configuration file, it will
       # be used by the database tasks class to dump only the specified search
       # path. Here we add also ChronoModel's temporal and history schemas to

--- a/lib/active_record/tasks/chronomodel_database_tasks.rb
+++ b/lib/active_record/tasks/chronomodel_database_tasks.rb
@@ -25,7 +25,7 @@ module ActiveRecord
         set_psql_env
 
         args = ['-c', '-f', target.to_s]
-        args << configuration['database']
+        args << configuration[:database]
 
         run_cmd "pg_dump", args, 'dumping data'
       end
@@ -34,7 +34,7 @@ module ActiveRecord
         set_psql_env
 
         args = ['-f', source]
-        args << configuration['database']
+        args << configuration[:database]
 
         run_cmd "psql", args, 'loading data'
       end

--- a/lib/chrono_model.rb
+++ b/lib/chrono_model.rb
@@ -71,6 +71,10 @@ end
 
 if defined?(Rails::DBConsole)
   Rails::DBConsole.instance_eval do
-    prepend ChronoModel::Patches::DBConsole
+    if Rails.version < '6.1'
+      prepend ChronoModel::Patches::DBConsole::Config
+    else
+      prepend ChronoModel::Patches::DBConsole::DbConfig
+    end
   end
 end

--- a/lib/chrono_model/patches/db_console.rb
+++ b/lib/chrono_model/patches/db_console.rb
@@ -1,11 +1,27 @@
+# frozen_string_literal: true
+
 module ChronoModel
   module Patches
-
     module DBConsole
-      def config
-        super.dup.tap {|config| config['adapter'] = 'postgresql/chronomodel' }
+      module Config
+        def config
+          super.dup.tap { |config| config['adapter'] = 'postgresql/chronomodel' }
+        end
+      end
+
+      module DbConfig
+        def db_config
+          return @patched_db_config if @patched_db_config
+
+          original_db_config = super
+          patched_db_configuration_hash = original_db_config.configuration_hash.dup.tap do |config|
+            config[:adapter] = 'postgresql/chronomodel'
+          end
+          original_db_config.instance_variable_set :@configuration_hash, patched_db_configuration_hash
+
+          @patched_db_config = original_db_config
+        end
       end
     end
-
   end
 end

--- a/lib/chrono_model/patches/relation.rb
+++ b/lib/chrono_model/patches/relation.rb
@@ -37,7 +37,13 @@ module ChronoModel
         #
         return if join.left.respond_to?(:as_of_time)
 
-        model = ChronoModel.history_models[join.left.table_name]
+        model =
+          if (join.left.respond_to?(:table_name))
+            ChronoModel.history_models[join.left.table_name]
+          else
+            ChronoModel.history_models[join.left]
+          end
+
         return unless model
 
         join.left = ChronoModel::Patches::JoinNode.new(

--- a/lib/chrono_model/railtie.rb
+++ b/lib/chrono_model/railtie.rb
@@ -14,13 +14,15 @@ module ChronoModel
       #
       ActiveRecord::Tasks::DatabaseTasks.register_task(/chronomodel/, tasks_class)
 
-      # Make schema:dump and schema:load invoke structure:dump and structure:load
-      Rake::Task['db:schema:dump'].clear.enhance(['environment']) do
-        Rake::Task['db:structure:dump'].invoke
-      end
+      if Rails.version < '6.1'
+        # Make schema:dump and schema:load invoke structure:dump and structure:load
+        Rake::Task['db:schema:dump'].clear.enhance(['environment']) do
+          Rake::Task['db:structure:dump'].invoke
+        end
 
-      Rake::Task['db:schema:load'].clear.enhance(['environment']) do
-        Rake::Task['db:structure:load'].invoke
+        Rake::Task['db:schema:load'].clear.enhance(['environment']) do
+          Rake::Task['db:structure:load'].invoke
+        end
       end
 
       desc "Dumps database into db/data.NOW.sql or file specified via DUMP="

--- a/lib/chrono_model/time_machine/timeline.rb
+++ b/lib/chrono_model/time_machine/timeline.rb
@@ -24,12 +24,13 @@ module ChronoModel
 
         if assocs.present?
           assocs.each do |ass|
+            association_quoted_table_name = connection.quote_table_name(ass.table_name)
             # `join` first, then use `where`s
             relation =
               if ass.belongs_to?
-                relation.joins("LEFT JOIN #{ass.table_name} ON #{ass.table_name}.id = #{table_name}.#{ass.foreign_key}")
+                relation.joins("LEFT JOIN #{association_quoted_table_name} ON #{association_quoted_table_name}.#{ass.association_primary_key} = #{quoted_table_name}.#{ass.foreign_key}")
               else
-                relation.joins("LEFT JOIN #{ass.table_name} ON #{ass.table_name}.#{ass.foreign_key} = #{table_name}.id")
+                relation.joins("LEFT JOIN #{association_quoted_table_name} ON #{association_quoted_table_name}.#{ass.foreign_key} = #{quoted_table_name}.#{primary_key}")
               end
           end
         end

--- a/lib/chrono_model/time_machine/timeline.rb
+++ b/lib/chrono_model/time_machine/timeline.rb
@@ -23,7 +23,15 @@ module ChronoModel
           select("DISTINCT UNNEST(ARRAY[#{fields.join(',')}]) AS ts")
 
         if assocs.present?
-          relation = relation.joins(*assocs.map(&:name))
+          assocs.each do |ass|
+            # `join` first, then use `where`s
+            relation =
+              if ass.belongs_to?
+                relation.joins("LEFT JOIN #{ass.table_name} ON #{ass.table_name}.id = #{table_name}.#{ass.foreign_key}")
+              else
+                relation.joins("LEFT JOIN #{ass.table_name} ON #{ass.table_name}.#{ass.foreign_key} = #{table_name}.id")
+              end
+          end
         end
 
         relation = relation.
@@ -32,7 +40,7 @@ module ChronoModel
         relation = relation.from(%["public".#{quoted_table_name}]) unless self.chrono?
         relation = relation.where(id: rid) if rid
 
-        sql = "SELECT ts FROM ( #{relation.to_sql} ) foo WHERE ts IS NOT NULL"
+        sql = "SELECT ts FROM ( #{relation.to_sql} ) AS foo WHERE ts IS NOT NULL"
 
         if options.key?(:before)
           sql << " AND ts < '#{Conversions.time_to_utc_string(options[:before])}'"
@@ -49,8 +57,6 @@ module ChronoModel
         end
 
         sql << " LIMIT #{options[:limit].to_i}" if options.key?(:limit)
-
-        sql.gsub! 'INNER JOIN', 'LEFT OUTER JOIN'
 
         connection.on_schema(Adapter::HISTORY_SCHEMA) do
           connection.select_values(sql, "#{self.name} periods").map! do |ts|

--- a/lib/chrono_model/time_machine/timeline.rb
+++ b/lib/chrono_model/time_machine/timeline.rb
@@ -28,7 +28,7 @@ module ChronoModel
             # `join` first, then use `where`s
             relation =
               if ass.belongs_to?
-                relation.joins("LEFT JOIN #{association_quoted_table_name} ON #{association_quoted_table_name}.#{ass.association_primary_key} = #{quoted_table_name}.#{ass.foreign_key}")
+                relation.joins("LEFT JOIN #{association_quoted_table_name} ON #{association_quoted_table_name}.#{ass.association_primary_key} = #{quoted_table_name}.#{ass.association_foreign_key}")
               else
                 relation.joins("LEFT JOIN #{association_quoted_table_name} ON #{association_quoted_table_name}.#{ass.foreign_key} = #{quoted_table_name}.#{primary_key}")
               end

--- a/spec/chrono_model/history_models_spec.rb
+++ b/spec/chrono_model/history_models_spec.rb
@@ -11,6 +11,9 @@ describe ChronoModel do
       # support/time_machine/structure
       expected['foos']     = Foo::History     if defined?(Foo::History)
       expected['bars']     = Bar::History     if defined?(Bar::History)
+      expected['moos']     = Moo::History     if defined?(Moo::History)
+      expected['boos']     = Boo::History     if defined?(Boo::History)
+
       expected['sub_bars'] = SubBar::History  if defined?(SubBar::History)
 
       # default_scope_spec

--- a/spec/chrono_model/time_machine/keep_cool_spec.rb
+++ b/spec/chrono_model/time_machine/keep_cool_spec.rb
@@ -23,5 +23,9 @@ describe ChronoModel::TimeMachine do
     it { expect(Foo.joins(bars: :sub_bars).first.bars.joins(:sub_bars).first.sub_bars.first.name).to eq 'new sub-bar' }
 
     it { expect(Foo.first.bars.includes(:sub_bars)).to eq [ $t.bar ] }
+
+    it { expect(Moo.first.boos).to eq(Boo.all)}
+    it { expect(Moo.first.boos.as_of(Time.new)).to eq(Boo.all.as_of(Time.new))}
+
   end
 end


### PR DESCRIPTION
Bringing AR 6.1 compatibility require more work, because Rails 6.1 supports multiple databases and that required a complete rewrite of the database configuration

The method used by Chrono Model to implement rake tasks, `current_config`, is deprecated and will be removed in 6.2, but changing the rake tasks should not be a huge deal

Also, some `schema` related are deprecated and will be removed in Rails 6.2

TODO:
- [x] Fix data dump
- [x] Fix add_index and remove_index with Ruby 3.x
- [x] Fix other failing specs