### PR TITLE
Increase time in spec

### DIFF
--- a/spec/chrono_model/time_machine/as_of_spec.rb
+++ b/spec/chrono_model/time_machine/as_of_spec.rb
@@ -157,14 +157,14 @@ describe ChronoModel::TimeMachine do
 
 
     it 'does not raise RecordNotFound when no history records are found' do
-      expect { $t.foo.as_of(1.minute.ago) }.to_not raise_error
+      expect { $t.foo.as_of(5.minutes.ago) }.to_not raise_error
 
-      expect($t.foo.as_of(1.minute.ago)).to be(nil)
+      expect($t.foo.as_of(5.minutes.ago)).to be(nil)
     end
 
 
     it 'raises ActiveRecord::RecordNotFound in the bang variant' do
-      expect { $t.foo.as_of!(1.minute.ago) }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { $t.foo.as_of!(5.minutes.ago) }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
 


### PR DESCRIPTION
Since the tested table is created once, it may happen that some as_of
tests did not complete within 1 minute, raising errors

This is just a workaround, a proper solution should be implemented in a future
refactor