### PR TITLE
Fix conversion of Pathname to String

### DIFF
--- a/lib/active_record/tasks/chronomodel_database_tasks.rb
+++ b/lib/active_record/tasks/chronomodel_database_tasks.rb
@@ -24,7 +24,7 @@ module ActiveRecord
       def data_dump(target)
         set_psql_env
 
-        args = ['-c', '-f', target]
+        args = ['-c', '-f', target.to_s]
         args << configuration['database']
 
         run_cmd "pg_dump", args, 'dumping data'


### PR DESCRIPTION
This error is thrown by all the supported Rails versions and is surprisingly not being detected by specs

Until further investigation, this commit fixes the wrong behavior