### PR TITLE
Cut a new release

### DIFF
--- a/chrono_model.gemspec
+++ b/chrono_model.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.version       = ChronoModel::VERSION
 
+  gem.metadata['rubygems_mfa_required'] = 'true'
+
   gem.metadata = {
     'bug_tracker_uri' => 'https://github.com/ifad/chronomodel/issues',
     'homepage_uri' => 'https://github.com/ifad/chronomodel',

--- a/lib/chrono_model/version.rb
+++ b/lib/chrono_model/version.rb
@@ -1,3 +1,3 @@
 module ChronoModel
-  VERSION = "1.2.2"
+  VERSION = "2.0.0"
 end


### PR DESCRIPTION
There are a lot of changes between v1.2.2 and master back from 2019, I don't know if there is a breaking one and we should bump the major

Please advise if #100 requires PG >= 12 and we should drop PG 9 (and edit readme accordingly)

https://github.com/ifad/chronomodel/compare/v1.2.2...076e870
