### PR TITLE
Remove redundant activerecord dependency

### DIFF
--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -1,6 +1,5 @@
 source "https://rubygems.org"
 
-gem "activerecord", "~> 5.0.0"
 gem "rails", "~> 5.0.0"
 
 # Fix code coverage on old Ruby versions

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -1,6 +1,5 @@
 source "https://rubygems.org"
 
-gem "activerecord", "~> 5.1.0"
 gem "rails", "~> 5.1.0"
 
 # Fix code coverage on old Ruby versions

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -1,6 +1,5 @@
 source "https://rubygems.org"
 
-gem "activerecord", "~> 5.2.0"
 gem "rails", "~> 5.2.0"
 
 # Fix code coverage on old Ruby versions

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -1,6 +1,5 @@
 source "https://rubygems.org"
 
-gem "activerecord", "~> 6.0.0"
 gem "rails", "~> 6.0.0"
 
 gemspec :path => "../"

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -1,6 +1,5 @@
 source "https://rubygems.org"
 
-gem "activerecord", "~> 6.1.0"
 gem "rails", "~> 6.1.0"
 
 gemspec :path => "../"

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -1,6 +1,5 @@
 source "https://rubygems.org"
 
-gem "activerecord", "~> 7.0.0"
 gem "rails", "~> 7.0.0"
 
 gemspec :path => "../"

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -1,6 +1,5 @@
 source "https://rubygems.org"
 
 gem 'rails', github: 'rails/rails', branch: 'main'
-gem 'activerecord', github: 'rails/rails', branch: 'main'
 
 gemspec :path => "../"


### PR DESCRIPTION
activerecord is a dependency of rails, so it is not needed to specify
it for testing purposes