### PR TITLE
Check module inclusion instead of respond_to?

### DIFF
--- a/lib/chrono_model/patches/association.rb
+++ b/lib/chrono_model/patches/association.rb
@@ -35,7 +35,7 @@ module ChronoModel
 
       private
         def _chrono_record?
-          owner.respond_to?(:as_of_time) && owner.as_of_time.present?
+          owner.class.include?(ChronoModel::Patches::AsOfTimeHolder) && owner.as_of_time.present?
         end
 
         def _chrono_target?

--- a/spec/chrono_model/time_machine/delegate_missing_to_spec.rb
+++ b/spec/chrono_model/time_machine/delegate_missing_to_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+require 'support/time_machine/structure'
+
+if Rails.version >= '5.1'
+  describe 'delegate_missing_to' do
+    include ChronoTest::TimeMachine::Helpers
+
+    adapter.create_table 'attachments' do |t|
+      t.integer :blob_id
+    end
+
+    adapter.create_table 'blobs' do |t|
+      t.string :name
+    end
+
+    class ::Attachment < ActiveRecord::Base
+      belongs_to :blob
+      delegate_missing_to :blob
+    end
+
+    class ::Blob < ActiveRecord::Base
+      has_many :attachments
+    end
+
+    let(:attachment) { Attachment.create!(blob: Blob.create!(name: 'test')).reload }
+
+    it 'does not raise errors' do
+      expect {
+        attachment.blob
+      }.not_to raise_error
+    end
+
+    it 'allows delegation to associated models' do
+      expect(attachment.name).to eq 'test'
+    end
+  end
+end


### PR DESCRIPTION
Checks if the module `AsOfTimeHolder` is included in the model rather
than using `respond_to?` to prevent stack overflow when a model
delegates missing methods to an association.

Fix #131