### PR TITLE
Do not test Rails 6.x against ruby head

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -38,12 +38,6 @@ jobs:
             gemfile: rails_edge
             experimental: true
           - ruby-version: 'head'
-            gemfile: rails_6.0
-            experimental: true
-          - ruby-version: 'head'
-            gemfile: rails_6.1
-            experimental: true
-          - ruby-version: 'head'
             gemfile: rails_7.0
             experimental: true
           - ruby-version: 'head'


### PR DESCRIPTION
Rails 6.x is not officially compatible with Ruby 3.1

Since Ruby edge is now resolving to >= 3.1, this commit excludes
unsupported combinations from the matrix