### PR TITLE
Ensure structure dump includes Chronomodel schemas

### DIFF
--- a/spec/aruba/fixtures/database_with_schema_search_path.yml
+++ b/spec/aruba/fixtures/database_with_schema_search_path.yml
@@ -1,0 +1,13 @@
+default: &default
+  adapter: chronomodel
+  encoding: unicode
+  pool: 20
+  database: chronomodel_railsapp
+  host: <%= ENV['CI'] ? 'localhost' : '' %>
+  schema_search_path: 'public'
+
+development:
+  <<: *default
+
+test:
+  <<: *default

--- a/spec/aruba/rake_task_spec.rb
+++ b/spec/aruba/rake_task_spec.rb
@@ -22,6 +22,18 @@ describe 'rake tasks', type: :aruba do
     it { expect(last_command_started).to be_successfully_executed }
     it { expect('db/test.sql').to be_an_existing_file }
     it { expect('db/test.sql').not_to have_file_content(/\A--/) }
+
+    context 'with schema_search_path option' do
+      let(:database_yml) { 'fixtures/database_with_schema_search_path.yml' }
+
+      before { run_command_and_stop("bundle exec rake #{dump_schema_task} SCHEMA=db/test.sql") }
+
+      it 'includes chronomodel schemas' do
+        expect('db/test.sql').to have_file_content(/^CREATE SCHEMA IF NOT EXISTS history;$/)
+          .and have_file_content(/^CREATE SCHEMA IF NOT EXISTS temporal;$/)
+          .and have_file_content(/^CREATE SCHEMA IF NOT EXISTS public;$/)
+      end
+    end
   end
 
   describe 'db:schema:load' do


### PR DESCRIPTION
When `schema_search_path` option is specified, structure dump may
exclude Chronomodel schemas if they have not been included in the
Configuration.

This change ensures that extra arguments are passed to the command line
to include required schemas

Fix: 134