### PR TITLE
Allow options in remove_column migration

### DIFF
--- a/lib/chrono_model/adapter/migrations.rb
+++ b/lib/chrono_model/adapter/migrations.rb
@@ -159,7 +159,7 @@ module ChronoModel
       # view, then drop the column from the table in the temporal schema and
       # eventually recreate the triggers.
       #
-      def remove_column(table_name, *)
+      def remove_column(table_name, column_name, type = nil, **options)
         return super unless is_chrono?(table_name)
         drop_and_recreate_public_view(table_name) { super }
       end

--- a/spec/chrono_model/adapter/migrations_spec.rb
+++ b/spec/chrono_model/adapter/migrations_spec.rb
@@ -332,7 +332,7 @@ describe ChronoModel::Adapter do
 
     with_temporal_table do
       before :all do
-        adapter.remove_column table, :foo
+        adapter.remove_column table, :foo, :integer, default: 0
       end
 
       it { is_expected.to have_columns(resulting_columns) }
@@ -346,7 +346,7 @@ describe ChronoModel::Adapter do
 
     with_plain_table do
       before :all do
-        adapter.remove_column table, :foo
+        adapter.remove_column table, :foo, :integer, default: 0
       end
 
       it { is_expected.to have_columns(resulting_columns) }


### PR DESCRIPTION
Keeps compatibility with Postgres adapter

Fix #144