### PR TITLE
Make `_find_record` behavior consistent with AR 7

### DIFF
--- a/lib/chrono_model/time_machine/history_model.rb
+++ b/lib/chrono_model/time_machine/history_model.rb
@@ -10,12 +10,12 @@ module ChronoModel
         scope :chronological, -> { order(Arel.sql('lower(validity) ASC')) }
       end
 
-      # ACTIVE RECORD 7 does not call class.find but a new internal method called _find_record
+      # ACTIVE RECORD 7 does not call `class.find` but a new internal method called `_find_record`
       def _find_record(options)
         if options && options[:lock]
-          self.class.preload(strict_loaded_associations).lock(options[:lock]).find_by_hid(hid)
+          self.class.preload(strict_loaded_associations).lock(options[:lock]).find_by!(hid: hid)
         else
-          self.class.preload(strict_loaded_associations).find_by_hid(hid)
+          self.class.preload(strict_loaded_associations).find_by!(hid: hid)
         end
       end
 


### PR DESCRIPTION
`find_by` is not the same as `find`, because it returns `nil` if the
object has not been found.

This change raises an `ActiveRecord::RecordNotFound Exception` to
match ActiveRecord API