### PR TITLE
Switch history primary key to bigserial

### DIFF
--- a/lib/chrono_model/adapter/ddl.rb
+++ b/lib/chrono_model/adapter/ddl.rb
@@ -52,7 +52,7 @@ module ChronoModel
 
           execute <<-SQL
             CREATE TABLE #{table} (
-              hid         SERIAL PRIMARY KEY,
+              hid         BIGSERIAL PRIMARY KEY,
               validity    tsrange NOT NULL,
               recorded_at timestamp NOT NULL DEFAULT timezone('UTC', now())
             ) INHERITS ( #{parent} )

--- a/spec/support/matchers/column.rb
+++ b/spec/support/matchers/column.rb
@@ -87,7 +87,7 @@ module ChronoTest::Matchers
         super([
           ['validity',    'tsrange'],
           ['recorded_at', 'timestamp without time zone'],
-          ['hid',         'integer']
+          ['hid',         'bigint']
         ], history_schema)
       end
     end


### PR DESCRIPTION
History tables store a representation of the current record itself, so
the number of historical records will be always greater than or equal
to the current ones.

When the number of records grow, there is less space for historical ids,
but it is logic to expect the opposite (more records, more need for historical versions)

Given also that starting from Rails 5.1 ids are stored as `bigint`, this
commit changes the default hid type to bigserial

Close #153

Ref:
- rails/rails#26266