### PR TITLE
Fix history update

### DIFF
--- a/lib/chrono_model/time_machine/history_model.rb
+++ b/lib/chrono_model/time_machine/history_model.rb
@@ -143,15 +143,15 @@ module ChronoModel
       end
 
       def save(*)
-        self.class.with_hid_pkey { super }
+        with_hid_pkey { super }
       end
 
       def save!(*)
-        self.class.with_hid_pkey { super }
+        with_hid_pkey { super }
       end
 
       def update_columns(*)
-        self.class.with_hid_pkey { super }
+        with_hid_pkey { super }
       end
 
       def historical?
@@ -219,6 +219,17 @@ module ChronoModel
 
       def recorded_at
         ChronoModel::Conversions.string_to_utc_time attributes_before_type_cast['recorded_at']
+      end
+
+      private
+
+      def with_hid_pkey
+        old_primary_key = @primary_key
+        @primary_key = :hid
+
+        self.class.with_hid_pkey { yield }
+      ensure
+        @primary_key = old_primary_key
       end
     end
 

--- a/spec/chrono_model/time_machine/manipulations_spec.rb
+++ b/spec/chrono_model/time_machine/manipulations_spec.rb
@@ -7,6 +7,8 @@ describe ChronoModel::TimeMachine do
   describe '#save' do
     subject { $t.bar.history.first }
 
+    let(:another_historical_object) { $t.bar.history.second }
+
     it do
       with_revert do
         subject.name = 'modified bar history'
@@ -14,6 +16,7 @@ describe ChronoModel::TimeMachine do
         subject.reload
 
         is_expected.to be_a(Bar::History)
+        expect(another_historical_object.name).not_to eq 'modified bar history'
         expect(subject.name).to eq 'modified bar history'
       end
     end
@@ -22,6 +25,8 @@ describe ChronoModel::TimeMachine do
   describe '#save!' do
     subject { $t.bar.history.second }
 
+    let(:first_historical_object) { $t.bar.history.first }
+
     it do
       with_revert do
         subject.name = 'another modified bar history'
@@ -29,6 +34,24 @@ describe ChronoModel::TimeMachine do
         subject.reload
 
         is_expected.to be_a(Bar::History)
+        expect(first_historical_object.name).not_to eq 'another modified bar history'
+        expect(subject.name).to eq 'another modified bar history'
+      end
+    end
+  end
+
+  describe '#update_columns' do
+    subject { $t.bar.history.first }
+
+    let(:another_historical_object) { $t.bar.history.second }
+
+    it do
+      with_revert do
+        subject.update_columns name: 'another modified bar history'
+        subject.reload
+
+        is_expected.to be_a(Bar::History)
+        expect(another_historical_object.name).not_to eq 'another modified bar history'
         expect(subject.name).to eq 'another modified bar history'
       end
     end


### PR DESCRIPTION
Temporarily change primary key object instance variable to `:hid` to
prevent unwanted changes to the whole history

Fix #167