### PR TITLE
Chore/use logger

### DIFF
--- a/lib/chrono_model/json.rb
+++ b/lib/chrono_model/json.rb
@@ -4,7 +4,9 @@ module ChronoModel
     extend self
 
     def create
-      puts "ChronoModel: WARNING - JSON ops are deprecated. Please migrate to JSONB"
+      ActiveSupport::Deprecation.warn <<-MSG.squish
+        ChronoModel: JSON ops are deprecated. Please migrate to JSONB.
+      MSG
 
       adapter.execute 'CREATE OR REPLACE LANGUAGE plpythonu'
       adapter.execute File.read(sql 'json_ops.sql')

--- a/lib/chrono_model/time_machine.rb
+++ b/lib/chrono_model/time_machine.rb
@@ -12,8 +12,10 @@ module ChronoModel
 
     included do
       if table_exists? && !chrono?
-        puts  "ChronoModel: #{table_name} is not a temporal table. " \
-          "Please use `change_table :#{table_name}, temporal: true` in a migration."
+        logger.warn <<-MSG.squish
+          ChronoModel: #{table_name} is not a temporal table.
+          Please use `change_table :#{table_name}, temporal: true` in a migration.
+        MSG
       end
 
       history = ChronoModel::TimeMachine.define_history_model_for(self)

--- a/spec/chrono_model/json_ops_spec.rb
+++ b/spec/chrono_model/json_ops_spec.rb
@@ -5,12 +5,12 @@
 if ENV['HAVE_PLPYTHON'] == '1'
 
   require 'spec_helper'
-  require 'support/helpers'
+  require 'support/adapter/helpers'
 
   require 'chrono_model/json'
 
   describe 'JSON equality operator' do
-    include ChronoTest::Helpers::Adapter
+    include ChronoTest::Adapter::Helpers
 
     table 'json_test'
 


### PR DESCRIPTION
### Before

```
# rails c
3.1.2 :001 > Foo
ChronoModel: foos is not a temporal table. Please use `change_table :foos, temporal: true` in a migration.
 => Foo(id: integer, name: string, created_at: datetime, updated_at: datetime) 

### development.log
```

### After

```
# rails c
3.1.2 :001 > Foo
ChronoModel: foos is not a temporal table. Please use `change_table :foos, temporal: true` in a migration.
 => Foo(id: integer, name: string, created_at: datetime, updated_at: datetime) 

# development.log
ChronoModel: foos is not a temporal table. Please use `change_table :foos, temporal: true` in a migration.
```