### PR TITLE
Assign default values for PKs

### DIFF
--- a/lib/chrono_model/adapter/ddl.rb
+++ b/lib/chrono_model/adapter/ddl.rb
@@ -31,7 +31,7 @@ module ChronoModel
               quote(column.default)
             end
 
-            next if column.name == pk || default.nil?
+            next if (column.name == pk && pk_and_sequence_for(current).present?) || default.nil?
 
             execute "ALTER VIEW #{table} ALTER COLUMN #{quote_column_name(column.name)} SET DEFAULT #{default}"
           end


### PR DESCRIPTION
This should allow tables with UUID PKs to work, as it'll add uuid generation as the default value to the PK column of the updatable view