### PR TITLE
Fix historic collection default ordering

### DIFF
--- a/lib/chrono_model/patches/relation.rb
+++ b/lib/chrono_model/patches/relation.rb
@@ -77,6 +77,26 @@ module ChronoModel
           model: self.model, as_of_time: as_of_time
         )
       end
+
+      def find_nth(*)
+        return super unless try(:history?)
+
+        with_hid_pkey { super }
+      end
+
+      def last(*)
+        return super unless try(:history?)
+
+        with_hid_pkey { super }
+      end
+
+      private
+
+        def ordered_relation
+          return super unless try(:history?)
+
+          with_hid_pkey { super }
+        end
     end
 
   end

--- a/spec/chrono_model/history_models_spec.rb
+++ b/spec/chrono_model/history_models_spec.rb
@@ -13,6 +13,7 @@ describe ChronoModel do
       expected['bars']     = Bar::History     if defined?(Bar::History)
       expected['moos']     = Moo::History     if defined?(Moo::History)
       expected['boos']     = Boo::History     if defined?(Boo::History)
+      expected['noos']     = Noo::History     if defined?(Noo::History)
 
       expected['sub_bars'] = SubBar::History  if defined?(SubBar::History)
       expected['sub_sub_bars'] = SubSubBar::History  if defined?(SubSubBar::History)

--- a/spec/chrono_model/time_machine/history_spec.rb
+++ b/spec/chrono_model/time_machine/history_spec.rb
@@ -18,6 +18,18 @@ describe ChronoModel::TimeMachine do
 
     it { expect(Foo.history.first).to be_a(Foo::History) }
     it { expect(Bar.history.first).to be_a(Bar::History) }
+
+    describe '.second' do
+      subject { Noo.history.second.name }
+
+      it { is_expected.to eq 'Historical Element 2' }
+    end
+
+    describe '.last' do
+      subject { Noo.history.last.name }
+
+      it { is_expected.to eq 'Historical Element 3' }
+    end
   end
 
   describe '#history' do
@@ -45,13 +57,14 @@ describe ChronoModel::TimeMachine do
     end
 
     describe 'allows a custom select list' do
-      it { expect($t.foo.history.select(:id).first.attributes.keys).to eq %w[id] }
+      it { expect($t.foo.history.select(:id).first.attributes.keys).to match_array %w[hid id] }
+      it { expect($t.foo.history.select(:id).last.attributes.keys).to match_array %w[hid id] }
     end
 
     describe 'does not add as_of_time when there are aggregates' do
       it { expect($t.foo.history.select('max(id)').to_sql).to_not match(/as_of_time/) }
 
-      it { expect($t.foo.history.except(:order).select('max(id) as foo, min(id) as bar').group('id').first.attributes.keys).to match_array %w[id foo bar] }
+      it { expect($t.foo.history.reorder('id').select('max(id) as foo, min(id) as bar').group('id').first.attributes.keys).to match_array %w[hid foo bar] }
     end
 
     context 'when finding historical elements by hid' do

--- a/spec/support/time_machine/structure.rb
+++ b/spec/support/time_machine/structure.rb
@@ -64,6 +64,11 @@ module ChronoTest::TimeMachine
     t.string     :name
   end
 
+  adapter.create_table 'noos', temporal: true do |t|
+    t.string     :name
+    t.string     :surname
+  end
+
   adapter.create_table 'sub_bars', temporal: true do |t|
     t.string     :name
     t.references :bar
@@ -130,6 +135,10 @@ module ChronoTest::TimeMachine
     has_and_belongs_to_many :boos, join_table: 'boos_moos'
   end
 
+  class ::Noo < ActiveRecord::Base
+    include ChronoModel::TimeMachine
+  end
+
   class ::SubBar < ActiveRecord::Base
     include ChronoModel::TimeMachine
 
@@ -148,7 +157,7 @@ module ChronoTest::TimeMachine
   # Master timeline, used in multiple specs. It is defined here
   # as a global variable to be able to be shared across specs.
   #
-  $t = Struct.new(:foo, :bar, :baz, :subbar, :foos, :bars, :boos, :moos).new
+  $t = Struct.new(:foo, :bar, :baz, :subbar, :foos, :bars, :boos, :moos, :noos).new
 
   # Set up associated records, with intertwined updates
   #
@@ -177,4 +186,8 @@ module ChronoTest::TimeMachine
   $t.moos = Array.new(2) { |i| ts_eval { Moo.create! name: "moo #{i}", boos: $t.boos } }
 
   $t.baz = Baz.create! name: 'baz', bar: $t.bar
+
+  first_noo = Noo.create! name: 'Historical Element 1'
+  Noo.create! name: 'Historical Element 2'
+  ts_eval(first_noo) { update! name: 'Historical Element 3' }
 end


### PR DESCRIPTION
Fix historic collection default ordering

Will also:
- Fix compatibility with Rails 7.1.0.alpha
- Instantiate historical records fetched from the DB via `select` like
  other AR objects, by adding a `hid: nil` attribute to represent the
  primary key

Fix #191
Fix #194
