### PR TITLE
Fix legacy specs

### DIFF
--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -4,6 +4,7 @@ gem "rails", "~> 5.0.0"
 
 # Fix code coverage on old Ruby versions
 if RUBY_VERSION < '2.5'
+  gem 'loofah', '~> 2.20.0'
   gem 'simplecov', '< 0.18.0'
 end
 

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -4,6 +4,7 @@ gem "rails", "~> 5.1.0"
 
 # Fix code coverage on old Ruby versions
 if RUBY_VERSION < '2.5'
+  gem 'loofah', '~> 2.20.0'
   gem 'simplecov', '< 0.18.0'
 end
 

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -9,6 +9,7 @@ end
 
 # Fix code coverage on old Ruby versions
 if RUBY_VERSION < '2.5'
+  gem 'loofah', '~> 2.20.0'
   gem 'simplecov', '< 0.18.0'
 end
 


### PR DESCRIPTION
loofah >= 2.21.0 raise an issue when starting old Ruby versions

```
lib/loofah/html4/document.rb:10:in `<module:HTML4>': uninitialized constant Nokogiri::HTML4 (NameError)
```

Ref: https://github.com/flavorjones/loofah/issues/266