### PR TITLE
Fix predecessor of current record

### DIFF
--- a/lib/chrono_model/time_machine.rb
+++ b/lib/chrono_model/time_machine.rb
@@ -172,7 +172,7 @@ module ChronoModel
     #
     def pred(options = {})
       if self.class.timeline_associations.empty?
-        history.order(Arel.sql('upper(validity) DESC')).offset(1).first
+        history.reverse_order.second
       else
         return nil unless (ts = pred_timestamp(options))
 

--- a/spec/chrono_model/time_machine/sequence_spec.rb
+++ b/spec/chrono_model/time_machine/sequence_spec.rb
@@ -20,6 +20,11 @@ RSpec.describe ChronoModel::TimeMachine do
       it { is_expected.to eq $t.foo.history[$t.foo.history.size - 2] }
     end
 
+    context 'with current records without an associated timeline' do
+      subject { $t.noo.pred }
+      it { is_expected.to eq $t.noo.history.first }
+    end
+
     context 'on records having history' do
       subject { $t.bar.pred }
       it { expect(subject.name).to eq 'bar bar' }


### PR DESCRIPTION
Order of history on current record was not correct, so `pred` returned
the second element of the history

This commit uses `reverse_order` to allow Active Record to properly 
reorder history. This change replaces

```sql
ORDER BY lower(validity) ASC, upper(validity) DESC
```

with a better

```sql
ORDER BY lower(validity) DESC
```

and also uses `second` instead of `offset(1).first` for clarity

Fix #201
