### PR TITLE
Keep original subclasses method in 7.0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,8 +15,8 @@ namespace :testapp do
   task :create do
     options = %w[
       --skip-action-cable
+      --skip-action-mailer
       --skip-action-text
-      --skip-active-job
       --skip-active-storage
       --skip-asset-pipeline
       --skip-bundle

--- a/lib/chrono_model/time_machine.rb
+++ b/lib/chrono_model/time_machine.rb
@@ -22,9 +22,14 @@ module ChronoModel
 
       class << self
         if Rails.version >= '7.0'
-          alias_method :subclasses_with_history, :subclasses
-          def subclasses
-            subclasses_with_history.reject(&:history?)
+          def subclasses(with_history: false)
+            subclasses = super()
+            subclasses.reject!(&:history?) unless with_history
+            subclasses
+          end
+
+          def subclasses_with_history
+            subclasses(with_history: true)
           end
 
           # `direct_descendants` is deprecated method in 7.0 and has been

--- a/spec/aruba/subclasses_spec.rb
+++ b/spec/aruba/subclasses_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+RSpec.describe 'subclasses spec', type: :aruba do
+  let(:action) { run_command('bundle exec rails runner "Foo.subclasses"') }
+  let(:last_command) { action && last_command_started }
+
+  before do
+    set_environment_variable 'CM_TEST_EAGER_LOAD', true
+    set_environment_variable 'CM_TEST_CACHE_CLASSES', true
+    copy_db_config
+    write_file(
+      'app/models/foo.rb',
+      "class Foo < ApplicationRecord; include ChronoModel::TimeMachine; end; "
+    )
+  end
+
+  it 'does not break when eager loading and caching classes' do
+    expect(last_command).to be_successfully_executed
+  end
+end

--- a/spec/fixtures/railsapp/config/application.rb
+++ b/spec/fixtures/railsapp/config/application.rb
@@ -3,7 +3,7 @@ require_relative 'boot'
 require "rails"
 # Pick the frameworks you want:
 require "active_model/railtie"
-# require "active_job/railtie"
+require "active_job/railtie"
 require "active_record/railtie"
 # require "active_storage/engine"
 require "action_controller/railtie"

--- a/spec/fixtures/railsapp/config/environments/development.rb
+++ b/spec/fixtures/railsapp/config/environments/development.rb
@@ -4,10 +4,10 @@ Rails.application.configure do
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
-  config.cache_classes = false
+  config.cache_classes = ENV['CM_TEST_CACHE_CLASSES'].present?
 
   # Do not eager load code on boot.
-  config.eager_load = false
+  config.eager_load = ENV['CM_TEST_EAGER_LOAD'].present?
 
   # Show full error reports.
   config.consider_all_requests_local = true


### PR DESCRIPTION
Invoke the super method without aliasing it so the descendants tracker can remove it when needed

Close #207