### PR TITLE
Add frozen string literal to production code

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -62,6 +62,11 @@ Naming/VariableNumber:
   Exclude:
     - 'lib/chrono_model/adapter/upgrade.rb'
 
+# This cop supports unsafe autocorrection (--autocorrect-all).
+Performance/UnfreezeString:
+  Exclude:
+    - 'lib/chrono_model/time_machine/timeline.rb'
+
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforceForPrefixed.
 Rails/Delegate:
@@ -145,9 +150,7 @@ Style/MultipleComparison:
 # SupportedStyles: literals, strict
 Style/MutableConstant:
   Exclude:
-    - 'lib/chrono_model/adapter.rb'
     - 'lib/chrono_model/conversions.rb'
-    - 'lib/chrono_model/version.rb'
 
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowedMethods.
@@ -206,14 +209,6 @@ Style/StderrPuts:
   Exclude:
     - 'lib/chrono_model/adapter/upgrade.rb'
 
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: Mode.
-Style/StringConcatenation:
-  Exclude:
-    - 'lib/chrono_model/adapter.rb'
-    - 'lib/chrono_model/json.rb'
-    - 'lib/chrono_model/time_machine/history_model.rb'
-
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle, ConsistentQuotesInMultiline.
 # SupportedStyles: single_quotes, double_quotes
@@ -224,7 +219,6 @@ Style/StringLiterals:
     - 'lib/chrono_model.rb'
     - 'lib/chrono_model/adapter/migrations.rb'
     - 'lib/chrono_model/adapter/upgrade.rb'
-    - 'lib/chrono_model/time_machine/history_model.rb'
     - 'lib/chrono_model/time_machine/time_query.rb'
     - 'lib/chrono_model/version.rb'
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -145,13 +145,6 @@ Style/MultipleComparison:
   Exclude:
     - 'lib/chrono_model/time_machine/time_query.rb'
 
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: literals, strict
-Style/MutableConstant:
-  Exclude:
-    - 'lib/chrono_model/conversions.rb'
-
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowedMethods.
 # AllowedMethods: be, be_a, be_an, be_between, be_falsey, be_kind_of, be_instance_of, be_truthy, be_within, eq, eql, end_with, include, match, raise_error, respond_to, start_with

--- a/lib/active_record/connection_adapters/chronomodel_adapter.rb
+++ b/lib/active_record/connection_adapters/chronomodel_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'chrono_model'
 
 module ActiveRecord

--- a/lib/active_record/tasks/chronomodel_database_tasks.rb
+++ b/lib/active_record/tasks/chronomodel_database_tasks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActiveRecord
   module Tasks
     class ChronomodelDatabaseTasks < PostgreSQLDatabaseTasks

--- a/lib/chrono_model.rb
+++ b/lib/chrono_model.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_record'
 
 require 'chrono_model/conversions'

--- a/lib/chrono_model/adapter.rb
+++ b/lib/chrono_model/adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_record/connection_adapters/postgresql_adapter'
 
 require 'chrono_model/adapter/migrations'
@@ -84,7 +86,7 @@ module ChronoModel
     define_method(:column_definitions) do |table_name|
       return super(table_name) unless is_chrono?(table_name)
 
-      on_schema(TEMPORAL_SCHEMA + ',' + self.schema_search_path, recurse: :ignore) { super(table_name) }
+      on_schema("#{TEMPORAL_SCHEMA},#{self.schema_search_path}", recurse: :ignore) { super(table_name) }
     end
 
     # Evaluates the given block in the temporal schema.

--- a/lib/chrono_model/adapter/ddl.rb
+++ b/lib/chrono_model/adapter/ddl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support/core_ext/string/strip'
 require 'multi_json'
 

--- a/lib/chrono_model/adapter/indexes.rb
+++ b/lib/chrono_model/adapter/indexes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ChronoModel
   class Adapter < ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
     module Indexes

--- a/lib/chrono_model/adapter/migrations.rb
+++ b/lib/chrono_model/adapter/migrations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ChronoModel
   class Adapter < ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
     module Migrations

--- a/lib/chrono_model/adapter/migrations_modules/legacy.rb
+++ b/lib/chrono_model/adapter/migrations_modules/legacy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ChronoModel
   class Adapter
     module MigrationsModules

--- a/lib/chrono_model/adapter/migrations_modules/stable.rb
+++ b/lib/chrono_model/adapter/migrations_modules/stable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ChronoModel
   class Adapter
     module MigrationsModules

--- a/lib/chrono_model/adapter/tsrange.rb
+++ b/lib/chrono_model/adapter/tsrange.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ChronoModel
   class Adapter < ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
     module TSRange

--- a/lib/chrono_model/adapter/upgrade.rb
+++ b/lib/chrono_model/adapter/upgrade.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ChronoModel
   class Adapter < ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
     module Upgrade

--- a/lib/chrono_model/conversions.rb
+++ b/lib/chrono_model/conversions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ChronoModel
   module Conversions
     extend self

--- a/lib/chrono_model/conversions.rb
+++ b/lib/chrono_model/conversions.rb
@@ -4,7 +4,7 @@ module ChronoModel
   module Conversions
     extend self
 
-    ISO_DATETIME = /\A(\d{4})-(\d\d)-(\d\d) (\d\d):(\d\d):(\d\d)(?:\.(\d+))?\z/
+    ISO_DATETIME = /\A(\d{4})-(\d\d)-(\d\d) (\d\d):(\d\d):(\d\d)(?:\.(\d+))?\z/.freeze
 
     def string_to_utc_time(string)
       return string if string.is_a?(Time)

--- a/lib/chrono_model/json.rb
+++ b/lib/chrono_model/json.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ChronoModel
   module Json
     extend self
@@ -19,7 +21,7 @@ module ChronoModel
     private
 
     def sql(file)
-      File.dirname(__FILE__) + '/../../sql/' + file
+      "#{File.dirname(__FILE__)}/../../sql/#{file}"
     end
 
     def adapter

--- a/lib/chrono_model/patches.rb
+++ b/lib/chrono_model/patches.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'chrono_model/patches/as_of_time_holder'
 require 'chrono_model/patches/as_of_time_relation'
 

--- a/lib/chrono_model/patches/as_of_time_holder.rb
+++ b/lib/chrono_model/patches/as_of_time_holder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ChronoModel
   module Patches
     # Added to classes that need to carry the As-Of date around

--- a/lib/chrono_model/patches/as_of_time_relation.rb
+++ b/lib/chrono_model/patches/as_of_time_relation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ChronoModel
   module Patches
     # This class is a dummy relation whose scope is only to pass around the

--- a/lib/chrono_model/patches/association.rb
+++ b/lib/chrono_model/patches/association.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ChronoModel
   module Patches
     # Patches ActiveRecord::Associations::Association to add support for

--- a/lib/chrono_model/patches/batches.rb
+++ b/lib/chrono_model/patches/batches.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ChronoModel
   module Patches
     module Batches

--- a/lib/chrono_model/patches/join_node.rb
+++ b/lib/chrono_model/patches/join_node.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ChronoModel
   module Patches
     # This class supports the AR 5.0 code that expects to receive an

--- a/lib/chrono_model/patches/preloader.rb
+++ b/lib/chrono_model/patches/preloader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ChronoModel
   module Patches
     # Patches ActiveRecord::Associations::Preloader to add support for

--- a/lib/chrono_model/patches/relation.rb
+++ b/lib/chrono_model/patches/relation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ChronoModel
   module Patches
     module Relation

--- a/lib/chrono_model/time_gate.rb
+++ b/lib/chrono_model/time_gate.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ChronoModel
   # Provides the TimeMachine API to non-temporal models that associate
   # temporal ones.

--- a/lib/chrono_model/time_machine.rb
+++ b/lib/chrono_model/time_machine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'chrono_model/time_machine/time_query'
 require 'chrono_model/time_machine/timeline'
 require 'chrono_model/time_machine/history_model'

--- a/lib/chrono_model/time_machine/history_model.rb
+++ b/lib/chrono_model/time_machine/history_model.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ChronoModel
   module TimeMachine
     module HistoryModel
@@ -126,7 +128,7 @@ module ChronoModel
         # current class or a descendant (or self).
         #
         def find_sti_class(type_name)
-          super(type_name + "::History")
+          super("#{type_name}::History")
         end
       end
 

--- a/lib/chrono_model/time_machine/time_query.rb
+++ b/lib/chrono_model/time_machine/time_query.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ChronoModel
   module TimeMachine
     #

--- a/lib/chrono_model/time_machine/timeline.rb
+++ b/lib/chrono_model/time_machine/timeline.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ChronoModel
   module TimeMachine
     module Timeline
@@ -35,12 +37,12 @@ module ChronoModel
         end
 
         relation = relation
-                   .order('ts ' << (options[:reverse] ? 'DESC' : 'ASC'))
+                   .order("ts #{options[:reverse] ? 'DESC' : 'ASC'}")
 
         relation = relation.from(%["public".#{quoted_table_name}]) unless self.chrono?
         relation = relation.where(id: rid) if rid
 
-        sql = "SELECT ts FROM ( #{relation.to_sql} ) AS foo WHERE ts IS NOT NULL"
+        sql = "SELECT ts FROM ( #{relation.to_sql} ) AS foo WHERE ts IS NOT NULL".dup
 
         if options.key?(:before)
           sql << " AND ts < '#{Conversions.time_to_utc_string(options[:before])}'"

--- a/lib/chrono_model/utilities.rb
+++ b/lib/chrono_model/utilities.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ChronoModel
   module Utilities
     # Amends the given history item setting a different period.

--- a/lib/chrono_model/version.rb
+++ b/lib/chrono_model/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ChronoModel
   VERSION = "1.2.2"
 end


### PR DESCRIPTION
Allows to slightly reduce memory usage.

In the benchmark sample, there is a reduction from:

    Total allocated: 685520 bytes (4936 objects)

to:

    Total allocated: 660144 bytes (4502 objects)