### PR TITLE
Patch preload association only when needed

### DIFF
--- a/lib/chrono_model/patches/relation.rb
+++ b/lib/chrono_model/patches/relation.rb
@@ -5,16 +5,16 @@ module ChronoModel
     module Relation
       include ChronoModel::Patches::AsOfTimeHolder
 
-      def preload_associations(records) # :nodoc:
-        return super unless ActiveRecord::Associations::Preloader.instance_methods.include?(:call)
-
-        preload = preload_values
-        preload += includes_values unless eager_loading?
-        scope = strict_loading_value ? StrictLoadingScope : nil
-        preload.each do |associations|
-          ActiveRecord::Associations::Preloader.new(
-            records: records, associations: associations, scope: scope, model: model, as_of_time: as_of_time
-          ).call
+      if ActiveRecord::Associations::Preloader.instance_methods.include?(:call)
+        def preload_associations(records) # :nodoc:
+          preload = preload_values
+          preload += includes_values unless eager_loading?
+          scope = strict_loading_value ? StrictLoadingScope : nil
+          preload.each do |associations|
+            ActiveRecord::Associations::Preloader.new(
+              records: records, associations: associations, scope: scope, model: model, as_of_time: as_of_time
+            ).call
+          end
         end
       end
 


### PR DESCRIPTION
`preload_associations(records)` was checking every time if ActiveRecord::Associations::Preloader instances responded to call. This can be done only once to decide whether if the method should be patched and improve both performance and memory usage

---

Memory before:

    Total allocated: 660144 bytes (4502 objects)

Memory after:

    Total allocated: 247344 bytes (4202 objects)