### PR TITLE
Add other scenarios to benchmark

### DIFF
--- a/benchmarks/benchmark.rb
+++ b/benchmarks/benchmark.rb
@@ -2,11 +2,60 @@
 
 # frozen_string_literal: true
 
+unless ENV['COVERAGE'].nil?
+  require 'simplecov'
+
+  SimpleCov.start
+  SimpleCov.command_name 'Bench'
+end
+
 require_relative 'benchmark_sample'
 require 'benchmark'
 
+ITERATIONS = 5_000
+
+Foo.create! name: 'Ciao'
+
+first_foo = Foo.first
+
 Benchmark.bmbm(30) do |x|
-  x.report('benchmark_sample') do
-    run_benchmark_sample
+  x.report('.merge') do
+    ITERATIONS.times { Foo.all.merge(Foo.all) }
+  end
+
+  x.report('.first') do
+    ITERATIONS.times { Foo.first }
+  end
+
+  x.report('.last') do
+    ITERATIONS.times { Foo.last }
+  end
+
+  x.report('.as_of.first') do
+    ITERATIONS.times { Foo.as_of(Time.now).first }
+  end
+
+  x.report('History.merge') do
+    ITERATIONS.times { Foo::History.all.merge(Foo::History.all) }
+  end
+
+  x.report('History.first') do
+    ITERATIONS.times { Foo::History.first }
+  end
+
+  x.report('History.last') do
+    ITERATIONS.times { Foo::History.last }
+  end
+
+  x.report('#history.first') do
+    ITERATIONS.times { first_foo.history.first }
+  end
+
+  x.report('#history.last') do
+    ITERATIONS.times { first_foo.history.last }
+  end
+
+  x.report('#as_of') do
+    ITERATIONS.times { first_foo.as_of(Time.now) }
   end
 end


### PR DESCRIPTION
Comparison:

Master @ c25a1574db53b1dd4e3e7ff1b1849a5acf70fbbb

```
                                     user     system      total        real
.merge                           0.049952   0.000165   0.050117 (  0.050112)
.first                           0.600933   0.020132   0.621065 (  0.698706)
.last                            0.636561   0.020165   0.656726 (  0.734477)
.as_of.first                     1.060459   0.024000   1.084459 (  1.464073)
History.merge                    0.057726   0.000151   0.057877 (  0.057875)
History.first                    0.720578   0.021867   0.742445 (  0.942331)
History.last                     0.771190   0.021951   0.793141 (  0.992843)
#history.first                   0.980279   0.024484   1.004763 (  1.357108)
#history.last                    1.044069   0.023971   1.068040 (  1.419861)
#as_of                           1.292923   0.026767   1.319690 (  1.704987)
```

Master after #217 and #218:

```
                                     user     system      total        real
.merge                           0.049882   0.000147   0.050029 (  0.050024)
.first                           0.564693   0.019807   0.584500 (  0.662243)
.last                            0.601412   0.019698   0.621110 (  0.698620)
.as_of.first                     1.019722   0.024197   1.043919 (  1.424934)
History.merge                    0.057530   0.000199   0.057729 (  0.057727)
History.first                    0.688982   0.021824   0.710806 (  0.911105)
History.last                     0.741591   0.022015   0.763606 (  0.962749)
#history.first                   0.933041   0.023525   0.956566 (  1.307604)
#history.last                    1.011747   0.023640   1.035387 (  1.386767)
#as_of                           1.262592   0.025238   1.287830 (  1.672108)
```

[ci skip]