### PR TITLE
Replace ternary operators with if...else

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,7 +13,7 @@ Lint/TripleQuotes:
 
 # Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes.
 Metrics/AbcSize:
-  Max: 72
+  Max: 73
 
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns, inherit_mode.
 # AllowedMethods: refine
@@ -26,7 +26,7 @@ Metrics/CyclomaticComplexity:
 
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns.
 Metrics/MethodLength:
-  Max: 44
+  Max: 62
 
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ModuleLength:
@@ -38,7 +38,7 @@ Metrics/ParameterLists:
 
 # Configuration parameters: AllowedMethods, AllowedPatterns.
 Metrics/PerceivedComplexity:
-  Max: 22
+  Max: 26
 
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: EnforcedStyleForLeadingUnderscores.
@@ -61,11 +61,6 @@ Naming/MethodParameterName:
 Naming/VariableNumber:
   Exclude:
     - 'lib/chrono_model/adapter/upgrade.rb'
-
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Performance/UnfreezeString:
-  Exclude:
-    - 'lib/chrono_model/time_machine/timeline.rb'
 
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforceForPrefixed.
@@ -130,14 +125,6 @@ Style/ModuleFunction:
 Style/MultilineIfModifier:
   Exclude:
     - 'lib/chrono_model/adapter.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
-Style/MultilineTernaryOperator:
-  Exclude:
-    - 'lib/chrono_model/patches/association.rb'
-    - 'lib/chrono_model/time_machine.rb'
-    - 'lib/chrono_model/time_machine/history_model.rb'
-    - 'lib/chrono_model/time_machine/timeline.rb'
 
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowMethodComparison, ComparisonsThreshold.

--- a/lib/chrono_model/adapter/tsrange.rb
+++ b/lib/chrono_model/adapter/tsrange.rb
@@ -34,9 +34,24 @@ module ChronoModel
 
         def extract_bounds(value)
           from, to = value[1..-2].split(',')
+
+          from_bound =
+            if value[1] == ',' || from == '-infinity'
+              nil
+            else
+              from[1..-2]
+            end
+
+          to_bound =
+            if value[-2] == ',' || to == 'infinity'
+              nil
+            else
+              to[1..-2]
+            end
+
           {
-            from: value[1] == ',' || from == '-infinity' ? nil : from[1..-2],
-            to: value[-2] == ',' || to == 'infinity' ? nil : to[1..-2]
+            from: from_bound,
+            to: to_bound
           }
         end
       end

--- a/lib/chrono_model/conversions.rb
+++ b/lib/chrono_model/conversions.rb
@@ -10,7 +10,13 @@ module ChronoModel
       return string if string.is_a?(Time)
 
       if string =~ ISO_DATETIME
-        usec = $7.nil? ? '000000' : $7.ljust(6, '0') # .1 is .100000, not .000001
+        # .1 is .100000, not .000001
+        usec =
+          if $7.nil?
+            '000000'
+          else
+            $7.ljust(6, '0')
+          end
         Time.utc $1.to_i, $2.to_i, $3.to_i, $4.to_i, $5.to_i, $6.to_i, usec.to_i
       end
     end

--- a/lib/chrono_model/patches/association.rb
+++ b/lib/chrono_model/patches/association.rb
@@ -41,9 +41,12 @@ module ChronoModel
       end
 
       def _chrono_target?
-        @_target_klass ||= reflection.options[:polymorphic] ?
-          owner.public_send(reflection.foreign_type).constantize :
-          reflection.klass
+        @_target_klass ||=
+          if reflection.options[:polymorphic]
+            owner.public_send(reflection.foreign_type).constantize
+          else
+            reflection.klass
+          end
 
         @_target_klass.chrono?
       end

--- a/lib/chrono_model/patches/relation.rb
+++ b/lib/chrono_model/patches/relation.rb
@@ -9,7 +9,8 @@ module ChronoModel
         def preload_associations(records) # :nodoc:
           preload = preload_values
           preload += includes_values unless eager_loading?
-          scope = strict_loading_value ? StrictLoadingScope : nil
+          scope = StrictLoadingScope if strict_loading_value
+
           preload.each do |associations|
             ActiveRecord::Associations::Preloader.new(
               records: records, associations: associations, scope: scope, model: model, as_of_time: as_of_time

--- a/lib/chrono_model/time_machine.rb
+++ b/lib/chrono_model/time_machine.rb
@@ -115,8 +115,12 @@ module ChronoModel
         changes = options.delete(:changes)
         assocs  = history.has_timeline(options)
 
-        attributes = changes.present? ?
-          Array.wrap(changes) : assocs.map(&:name)
+        attributes =
+          if changes.present?
+            Array.wrap(changes)
+          else
+            assocs.map(&:name)
+          end
 
         attribute_names_for_history_changes.concat(attributes.map(&:to_s))
       end
@@ -210,7 +214,11 @@ module ChronoModel
     # Returns the current history version
     #
     def current_version
-      self.historical? ? self.class.find(self.id) : self
+      if self.historical?
+        self.class.find(self.id)
+      else
+        self
+      end
     end
 
     # Returns the differences between this entry and the previous history one.
@@ -231,8 +239,12 @@ module ChronoModel
         old, new = ref.public_send(attr), self.public_send(attr)
 
         changes.tap do |c|
-          changed = old.respond_to?(:history_eql?) ?
-            !old.history_eql?(new) : old != new
+          changed =
+            if old.respond_to?(:history_eql?)
+              !old.history_eql?(new)
+            else
+              old != new
+            end
 
           c[attr] = [old, new] if changed
         end

--- a/lib/chrono_model/time_machine/history_model.rb
+++ b/lib/chrono_model/time_machine/history_model.rb
@@ -71,9 +71,12 @@ module ChronoModel
         end
 
         def virtual_table_at(time, table_name: nil)
-          virtual_name = table_name ?
-            connection.quote_table_name(table_name) :
-            superclass.quoted_table_name
+          virtual_name =
+            if table_name
+              connection.quote_table_name(table_name)
+            else
+              superclass.quoted_table_name
+            end
 
           "(#{at(time).to_sql}) #{virtual_name}"
         end

--- a/lib/chrono_model/time_machine/time_query.rb
+++ b/lib/chrono_model/time_machine/time_query.rb
@@ -23,11 +23,21 @@ module ChronoModel
           "NOT (#{build_time_query_at(time, range)})"
 
         when :before
-          op = options.fetch(:inclusive, true) ? '&&' : '@>'
+          op =
+            if options.fetch(:inclusive, true)
+              '&&'
+            else
+              '@>'
+            end
           build_time_query(['NULL', time_for_time_query(time, range)], range, op)
 
         when :after
-          op = options.fetch(:inclusive, true) ? '&&' : '@>'
+          op =
+            if options.fetch(:inclusive, true)
+              '&&'
+            else
+              '@>'
+            end
           build_time_query([time_for_time_query(time, range), 'NULL'], range, op)
 
         else
@@ -67,7 +77,11 @@ module ChronoModel
 
                  # If both edges of the range are the same the query fails using the '&&' operator.
                  # The correct solution is to use the <@ operator.
-                 time.first == time.last ? time.first : time
+                 if time.first == time.last
+                   time.first
+                 else
+                   time
+                 end
                else
                  time_for_time_query(time, range)
                end

--- a/spec/chrono_model/conversions_spec.rb
+++ b/spec/chrono_model/conversions_spec.rb
@@ -26,6 +26,13 @@ RSpec.describe ChronoModel::Conversions do
       it { expect(string_to_utc_time.usec).to eq 129_000 } # Ref Issue #32
     end
 
+    context 'with a valid UTC string without usec' do
+      let(:string) { '2017-02-06 09:46:31' }
+
+      it { is_expected.to be_a(Time) }
+      it { expect(string_to_utc_time.usec).to eq 0 }
+    end
+
     context 'with an invalid UTC time string' do
       let(:string) { 'foobar' }
 

--- a/spec/chrono_model/time_machine/history_spec.rb
+++ b/spec/chrono_model/time_machine/history_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe ChronoModel::TimeMachine do
     end
 
     describe 'from #as_of' do
-      subject { $t.foo.as_of(Time.now) }
+      subject { $t.foo.as_of(Time.now).current_version }
 
       it { is_expected.to eq $t.foo }
     end


### PR DESCRIPTION
Ternary operator are bad for coverage, in fact some branches were not tested because of wrong or missing specs.

Also, ternary operator on multiple lines are parsed as a single line, so they should be removed too

This commit also fixes a spec and adds a missing one for easy use cases