### PR TITLE
Use quoted table name

### DIFF
--- a/benchmarks/benchmark.rb
+++ b/benchmarks/benchmark.rb
@@ -60,6 +60,10 @@ Benchmark.bmbm(30) do |x|
     ITERATIONS.times { first_foo.as_of(Time.now) }
   end
 
+  x.report('#timeline') do
+    ITERATIONS.times { first_foo.timeline }
+  end
+
   x.report('TimeGate .merge') do
     ITERATIONS.times { Bar.merge(Bar.all) }
   end

--- a/lib/chrono_model/time_machine/timeline.rb
+++ b/lib/chrono_model/time_machine/timeline.rb
@@ -108,7 +108,7 @@ module ChronoModel
 
       def quoted_history_fields
         @quoted_history_fields ||= begin
-          validity = "#{connection.quote_table_name(table_name)}.#{connection.quote_column_name('validity')}"
+          validity = "#{quoted_table_name}.#{connection.quote_column_name('validity')}"
 
           %w[lower upper].map! { |func| "#{func}(#{validity})" }
         end


### PR DESCRIPTION
Retrieving quoted table name directly from the class instead of re-calculating it from the connection is an order of magnitude faster

```rb
class User < ActiveRecord::Base
  def self.qtn
    quoted_table_name
  end

  def self.cqtn
    connection.quote_table_name(table_name)
  end
end
```

Ruby 2.2 / Rails 5.0:
```
            User.qtn:  3003860.8 i/s
           User.cqtn:   259818.5 i/s - 11.56x  slower
```

Ruby 3.2 / Rails 7.0:

```
Comparison:
            User.qtn: 13504395.2 i/s
           User.cqtn:   517189.1 i/s - 26.11x  slower
```