### PR TITLE
Use default type cast for `recorded_at`

### DIFF
--- a/lib/chrono_model/time_machine/history_model.rb
+++ b/lib/chrono_model/time_machine/history_model.rb
@@ -222,10 +222,6 @@ module ChronoModel
       end
       alias as_of_time valid_to
 
-      def recorded_at
-        ChronoModel::Conversions.string_to_utc_time attributes_before_type_cast['recorded_at']
-      end
-
       # Starting from Rails 6.0, `.read_attribute` will use the memoized
       # `primary_key` if it detects that the attribute name is `id`.
       #


### PR DESCRIPTION
Previously, `recorded_at` was consistently returned in UTC format, with the reason for this decision not explicitly documented in the commit history.

This commit modifies the behavior to use the application's configured timezone for `recorded_at`, aligning with the default type cast for timestamp fields.

This adjustment ensures that timestamp data is presented in a more intuitive format for users, potentially enhancing user experience and data interpretation.

### Before:

```
Activity.last.history.first.recorded_at
=> 2024-01-05 14:40:18.656918 UTC
```

### After:

```
Activity.last.history.first.recorded_at
=> Fri, 05 Jan 2024 15:40:18.656918000 CET +01:00
```