### PR TITLE
Remove `string_to_utc_time` conversion function

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -8,7 +8,7 @@
 
 # Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes.
 Metrics/AbcSize:
-  Max: 73
+  Max: 71
 
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns, inherit_mode.
 # AllowedMethods: refine
@@ -17,11 +17,11 @@ Metrics/BlockLength:
 
 # Configuration parameters: AllowedMethods, AllowedPatterns.
 Metrics/CyclomaticComplexity:
-  Max: 21
+  Max: 20
 
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns.
 Metrics/MethodLength:
-  Max: 62
+  Max: 60
 
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ModuleLength:
@@ -33,7 +33,7 @@ Metrics/ParameterLists:
 
 # Configuration parameters: AllowedMethods, AllowedPatterns.
 Metrics/PerceivedComplexity:
-  Max: 26
+  Max: 25
 
 # Configuration parameters: MinNameLength, AllowNamesEndingInNumbers, AllowedNames, ForbiddenNames.
 # AllowedNames: as, at, by, cc, db, id, if, in, io, ip, of, on, os, pp, to

--- a/lib/chrono_model/conversions.rb
+++ b/lib/chrono_model/conversions.rb
@@ -6,19 +6,6 @@ module ChronoModel
 
     ISO_DATETIME = /\A(\d{4})-(\d\d)-(\d\d) (\d\d):(\d\d):(\d\d)(?:\.(\d+))?\z/
 
-    # rubocop:disable Style/PerlBackrefs
-    def string_to_utc_time(string)
-      return string if string.is_a?(Time)
-
-      return unless string =~ ISO_DATETIME
-
-      # .1 is .100000, not .000001
-      usec = $7.ljust(6, '0') unless $7.nil?
-
-      Time.utc $1.to_i, $2.to_i, $3.to_i, $4.to_i, $5.to_i, $6.to_i, usec.to_i
-    end
-    # rubocop:enable Style/PerlBackrefs
-
     def time_to_utc_string(time)
       time.to_fs(:db) << '.' << format('%06d', time.usec)
     end

--- a/lib/chrono_model/time_machine/timeline.rb
+++ b/lib/chrono_model/time_machine/timeline.rb
@@ -81,9 +81,7 @@ module ChronoModel
         sql << " LIMIT #{options[:limit].to_i}" if options.key?(:limit)
 
         connection.on_schema(Adapter::HISTORY_SCHEMA) do
-          connection.select_values(sql, "#{name} periods").map! do |ts|
-            Conversions.string_to_utc_time ts
-          end
+          connection.select_values(sql, "#{name} periods")
         end
       end
 

--- a/spec/chrono_model/conversions_spec.rb
+++ b/spec/chrono_model/conversions_spec.rb
@@ -3,43 +3,6 @@
 require 'spec_helper'
 
 RSpec.describe ChronoModel::Conversions do
-  describe '.string_to_utc_time' do
-    subject(:string_to_utc_time) { described_class.string_to_utc_time(string) }
-
-    context 'with a valid UTC time string' do
-      let(:string) { '2017-02-06 09:46:31.129626' }
-
-      it { is_expected.to be_a(Time) }
-      it { expect(string_to_utc_time.year).to  eq 2017 }
-      it { expect(string_to_utc_time.month).to eq 2 }
-      it { expect(string_to_utc_time.day).to   eq 6 }
-      it { expect(string_to_utc_time.hour).to  eq 9 }
-      it { expect(string_to_utc_time.min).to   eq 46 }
-      it { expect(string_to_utc_time.sec).to   eq 31 }
-      it { expect(string_to_utc_time.usec).to  eq 129_626 } # Ref Issue #32
-    end
-
-    context 'with a valid UTC string without least significant zeros' do
-      let(:string) { '2017-02-06 09:46:31.129' }
-
-      it { is_expected.to be_a(Time) }
-      it { expect(string_to_utc_time.usec).to eq 129_000 } # Ref Issue #32
-    end
-
-    context 'with a valid UTC string without usec' do
-      let(:string) { '2017-02-06 09:46:31' }
-
-      it { is_expected.to be_a(Time) }
-      it { expect(string_to_utc_time.usec).to eq 0 }
-    end
-
-    context 'with an invalid UTC time string' do
-      let(:string) { 'foobar' }
-
-      it { is_expected.to be_nil }
-    end
-  end
-
   describe '.time_to_utc_string' do
     subject { described_class.time_to_utc_string(time) }
 


### PR DESCRIPTION
This method was used in features that were removed (#268 and #271) and the reason for converting ts values selected from the timeline query is not explicitly documented in the commit history and appears to be redundant (they are already timestamps)

After conducting manual tests on the `usec`s, it was determined that
the issue reported in issue #32 is no longer valid.