### PR TITLE
Replace dependant with dependent

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ view and all the trigger machinery. Every other housekeeping of the temporal
 structure is handled behind the scenes by the other schema statements. E.g.:
 
  * `rename_table`  - renames tables, views, sequences, indexes and triggers
- * `drop_table`    - drops the temporal table and all dependant objects
+ * `drop_table`    - drops the temporal table and all dependent objects
  * `add_column`    - adds the column to the current table and updates triggers
  * `rename_column` - renames the current table column and updates the triggers
  * `remove_column` - removes the current table column and updates the triggers
@@ -279,12 +279,12 @@ cannot be deleted.
 
 ChronoModel currently performs upgrades by dropping and re-creating the views
 that give access to current data. If you have built other database objects on
-these views, the upgrade cannot be performed automatically as the dependant
+these views, the upgrade cannot be performed automatically as the dependent
 objects must be dropped first.
 
 When booting, ChronoModel will issue a warning in your logs about the need of
 a structure upgrade. Structure usually changes across versions. In this case,
-you need to set up a rake task that drops your dependant objects, runs
+you need to set up a rake task that drops your dependent objects, runs
 ChronoModel.upgrade! and then re-creates them.
 
 A migration system should be introduced, but it is seen as overkill for now,

--- a/lib/chrono_model/adapter/upgrade.rb
+++ b/lib/chrono_model/adapter/upgrade.rb
@@ -42,7 +42,7 @@ module ChronoModel
         return if upgrade.empty?
 
         logger.warn 'ChronoModel: There are tables needing a structure upgrade, and ChronoModel structures need to be recreated.'
-        logger.warn 'ChronoModel: Please run ChronoModel.upgrade! to attempt the upgrade. If you have dependant database objects'
+        logger.warn 'ChronoModel: Please run ChronoModel.upgrade! to attempt the upgrade. If you have dependent database objects'
         logger.warn 'ChronoModel: the upgrade will fail and you have to drop the dependent objects, run .upgrade! and create them'
         logger.warn 'ChronoModel: again. Sorry. Some features or the whole library may not work correctly until upgrade is complete.'
         logger.warn "ChronoModel: Tables pending upgrade: #{upgrade}"


### PR DESCRIPTION
"Dependant" is used as a noun when referring to someone who relies on another person or source for support or care.

"Dependent" is used as an adjective to describe something that relies on or is influenced by another thing.

It appears that `dependant` occurrences were always used as an adjective