### PR TITLE
Test against multiple PostgreSQL versions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,43 +14,43 @@ jobs:
     name: Ruby specs
     runs-on: ubuntu-latest
 
-    services:
-      db:
-        image: postgres:12
-        ports: ['5432:5432']
-        env:
-          POSTGRES_HOST_AUTH_METHOD: trust
-
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
     strategy:
       matrix:
         ruby-version: ['3.0', '3.1', '3.2', '3.3']
         gemfile: [rails_7.0, rails_7.1]
+        postgres-version: ['16']
         channel: ['stable']
 
         include:
+          # Test minimum required Ruby and Rails against PostgreSQL 12
+          - ruby-version: '3.0'
+            gemfile: rails_7.0
+            postgres-version: '12'
+            channel: 'stable'
+
           - ruby-version: '3.1'
             gemfile: rails_edge
+            postgres-version: '16'
             channel: 'experimental'
           - ruby-version: '3.2'
             gemfile: rails_edge
+            postgres-version: '16'
             channel: 'experimental'
           - ruby-version: '3.3'
             gemfile: rails_edge
+            postgres-version: '16'
             channel: 'experimental'
           - ruby-version: 'head'
             gemfile: rails_7.0
+            postgres-version: '16'
             channel: 'experimental'
           - ruby-version: 'head'
             gemfile: rails_7.1
+            postgres-version: '16'
             channel: 'experimental'
           - ruby-version: 'head'
             gemfile: rails_edge
+            postgres-version: '16'
             channel: 'experimental'
 
     env:
@@ -61,11 +61,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Database
+    - uses: ankane/setup-postgres@v1
+      with:
+        postgres-version: ${{ matrix.postgres-version }}
+        database: chronomodel
+    - name: Create Rails app database # FIXME: refactor when ankane/setup-postgres#9 will be merged
       run: |
-        psql -c "CREATE ROLE runner SUPERUSER LOGIN CREATEDB;" -U postgres -h localhost
-        psql -c "CREATE DATABASE chronomodel;" -U postgres -h localhost
-        psql -c "CREATE DATABASE chronomodel_railsapp;" -U postgres -h localhost
+        createdb chronomodel_railsapp
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/spec/aruba/rake_task_spec.rb
+++ b/spec/aruba/rake_task_spec.rb
@@ -77,6 +77,13 @@ RSpec.describe 'rake tasks', type: :aruba do
               contents.sub('username: postgres', "username: #{Etc.getlogin}")
             end
           end
+
+          # Hande GitHub Actions
+          if ENV['CI']
+            file_mangle!('config/database.yml') do |contents|
+              contents.sub('username: postgres', 'username: runner')
+            end
+          end
         end
 
         it { expect(last_command).to be_successfully_executed }

--- a/spec/config.github.yml
+++ b/spec/config.github.yml
@@ -1,5 +1,5 @@
 host: localhost
-username: postgres
+username: runner
 password: ""
 database: chronomodel
 pool: 11


### PR DESCRIPTION
This commit introduces an improvement in our testing strategy to ensure
broader compatibility across various PostgreSQL versions.

The primary focus remains on the latest stable release of PostgreSQL,
acknowledging the significance of maintaining support for older versions
to accommodate the longevity of applications.

To facilitate this, tests have been added to verify the application's
functionality against PostgreSQL 12.

Since `setup-postgres` action does not allow to create multiple
databases, consider a refactoring if ankane/setup-postgres#9 will be
merged.