### PR TITLE
Prevent scope leakage in HistoryModel.at queries

### DIFF
--- a/lib/chrono_model/time_machine/history_model.rb
+++ b/lib/chrono_model/time_machine/history_model.rb
@@ -82,8 +82,12 @@ module ChronoModel
 
         # Fetches history record at the given time
         #
+        # Build on an unscoped relation to avoid leaking outer predicates
+        # (e.g., through association scopes) into the inner subquery.
+        #
+        # @see https://github.com/ifad/chronomodel/issues/295
         def at(time)
-          time_query(:at, time).from(quoted_table_name).as_of_time!(time)
+          unscoped.time_query(:at, time).from(quoted_table_name).as_of_time!(time)
         end
 
         # Returns the history sorted by recorded_at

--- a/spec/chrono_model/time_machine/as_of_spec.rb
+++ b/spec/chrono_model/time_machine/as_of_spec.rb
@@ -153,6 +153,8 @@ RSpec.describe ChronoModel::TimeMachine do
       it { expect(Foo.as_of($t.subbar.ts[3]).includes(:bars, :sub_bars).first.sub_bars.first.name).to eq 'new sub-bar' }
 
       it { expect(Foo.as_of(Time.now).includes(:bars, :sub_bars, :sub_sub_bars).first.sub_sub_bars.compact.size).to eq 1 }
+
+      it { expect(Foo.as_of(Time.now).includes(:active_sub_bars).first.name).to eq 'new foo' }
     end
 
     it 'does not raise RecordNotFound when no history records are found' do

--- a/spec/support/time_machine/structure.rb
+++ b/spec/support/time_machine/structure.rb
@@ -75,6 +75,7 @@ module ChronoTest
     adapter.create_table 'sub_bars', temporal: true do |t|
       t.string     :name
       t.references :bar
+      t.boolean    :active, default: true
     end
 
     adapter.create_table 'sub_sub_bars', temporal: true do |t|
@@ -87,6 +88,8 @@ module ChronoTest
 
       belongs_to :foo
       has_many :sub_bars
+      has_many :active_sub_bars, -> { active }, class_name: 'SubBar'
+
       has_one :baz
 
       has_timeline with: :foo
@@ -121,6 +124,7 @@ module ChronoTest
       has_many :tars, foreign_key: :foo_refering, primary_key: :refee_foo
       has_many :sub_bars, through: :bars
       has_many :sub_sub_bars, through: :sub_bars
+      has_many :active_sub_bars, through: :bars
 
       belongs_to :goo, class_name: 'FooGoo', optional: true
     end
@@ -146,6 +150,8 @@ module ChronoTest
 
       belongs_to :bar
       has_many :sub_sub_bars
+
+      scope :active, -> { where(active: true) }
 
       has_timeline with: :bar
     end


### PR DESCRIPTION
Scoped association predicates were leaking into the temporal subquery
used by `HistoryModel.at` because the relation was built on the current
scope. When calling `as_of` with a scoped `has_many :through`,
the association’s where conditions could be propagated into the inner
`at` query. This filtered history by unrelated predicates and produced
incorrect results when resolving records at a given point in time.

Build the `at` relation from an unscoped base so the temporal query is
isolated from caller scopes and only reflects the `as_of` constraints
and history table. This mirrors Active Record internals, which construct
association and preloader scopes starting from klass.unscoped to avoid
scope contamination.

A regression spec exercises `as_of` with a scoped through association
and updates the test schema to introduce an active flag and scope on
`SubBar`, reproducing the failure and verifying the fix.

Fix https://github.com/ifad/chronomodel/issues/295