### PR TITLE
Change `load` method to match AR implementation

### DIFF
--- a/lib/chrono_model/patches/relation.rb
+++ b/lib/chrono_model/patches/relation.rb
@@ -23,10 +23,12 @@ module ChronoModel
         @values == klass.unscoped.as_of(as_of_time).values
       end
 
-      def load
-        return super unless @_as_of_time && !loaded?
+      def load(&block)
+        return super unless @_as_of_time && (!loaded? || scheduled?)
 
         super.each { |record| record.as_of_time!(@_as_of_time) }
+
+        self
       end
 
       def merge(*)

--- a/spec/chrono_model/time_machine/as_of_spec.rb
+++ b/spec/chrono_model/time_machine/as_of_spec.rb
@@ -181,5 +181,11 @@ RSpec.describe ChronoModel::TimeMachine do
       it { expect($t.baz.as_of($t.bar.ts[2]).bar.foo.name).to eq 'new foo' }
       it { expect($t.baz.as_of($t.bar.ts[3]).bar.foo.name).to eq 'new foo' }
     end
+
+    describe '#load' do
+      it 'returns a relation' do
+        expect(Foo.as_of(Time.now).load).to be_an(ActiveRecord::Relation)
+      end
+    end
   end
 end


### PR DESCRIPTION
`Relation#load` method:
- Show that a block is accepted as an argument
- Checks for `scheduled?` predicate
- Returns the `Relation` itself (not an array)

This signature is available from 7.0.0, the minimum requested AR version

Close #297

Ref:
- rails/rails@caa178c
- rails/rails@2a90104
