### PR TITLE
Remove `Relation#build_preloader`

### DIFF
--- a/lib/chrono_model/patches/relation.rb
+++ b/lib/chrono_model/patches/relation.rb
@@ -70,15 +70,6 @@ module ChronoModel
         )
       end
 
-      # Build a preloader at the +as_of_time+ of this relation.
-      # Pass the current model to define Relation
-      #
-      def build_preloader
-        ActiveRecord::Associations::Preloader.new(
-          model: model, as_of_time: as_of_time
-        )
-      end
-
       def find_nth(*)
         return super unless try(:history?)
 


### PR DESCRIPTION
This method has been removed from AR 7.x

Close #301

Ref:
- rails/rails@16e7846
- rails/rails#40776