### PR TITLE
Use string instead of symbol as primary key

### DIFF
--- a/lib/chrono_model/time_machine/history_model.rb
+++ b/lib/chrono_model/time_machine/history_model.rb
@@ -32,7 +32,7 @@ module ChronoModel
         #
         def with_hid_pkey
           old = primary_key
-          self.primary_key = :hid
+          self.primary_key = 'hid'
 
           yield
         ensure
@@ -239,7 +239,7 @@ module ChronoModel
 
       def with_hid_pkey(&block)
         old_primary_key = @primary_key
-        @primary_key = :hid
+        @primary_key = 'hid'
 
         self.class.with_hid_pkey(&block)
       ensure


### PR DESCRIPTION
`primary_key` is supposed to be a String, this will avoid a symbol to string conversion.

According to `profile_memory`, this change actually prevents 1 object allocation and save 40 bytes in
`lib/active_record/attribute_methods/primary_key.rb` each time `with_hid_pkey` is called

Ref: https://api.rubyonrails.org/v7.1.3.4/classes/ActiveRecord/AttributeMethods/PrimaryKey/ClassMethods.html#method-i-primary_key