### PR TITLE
Fix new RuboCop offence

### DIFF
--- a/lib/chrono_model/time_machine/timeline.rb
+++ b/lib/chrono_model/time_machine/timeline.rb
@@ -59,7 +59,7 @@ module ChronoModel
         relation = relation.from("public.#{quoted_table_name}") unless chrono?
         relation = relation.where(id: rid) if rid
 
-        sql = +"SELECT ts FROM ( #{relation.to_sql} ) AS foo WHERE ts IS NOT NULL"
+        sql = "SELECT ts FROM ( #{relation.to_sql} ) AS foo WHERE ts IS NOT NULL"
 
         if options.key?(:before)
           sql << " AND ts < '#{Conversions.time_to_utc_string(options[:before])}'"


### PR DESCRIPTION
`Style/RedundantInterpolationUnfreeze`. In Ruby >= 3.0, interpolated strings are already unfrozen.

```
Comparison:
         "test #{1}":  8929208.6 i/s
        +"test #{1}":  7853049.9 i/s - 1.14x  (± 0.00) slower
```