### PR TITLE
Ignore bundled gems into `gemfiles` folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,5 +57,7 @@ Gemfile.lock
 
 # Custom
 gemfiles/*.lock
+gemfiles/.bundle
+gemfiles/vendor
 spec/config.yml
 spec/debug.log


### PR DESCRIPTION
Ignoring vendor folder at root level is not enough. For this use case, gemfiles should be also taken into consideration

Follow up: #358