### PR TITLE
Define column_definitions directly

### DIFF
--- a/lib/chrono_model/adapter.rb
+++ b/lib/chrono_model/adapter.rb
@@ -87,15 +87,10 @@ module ChronoModel
     # The default search path is included however, since the table
     # may reference types defined in other schemas, which result in their
     # names becoming schema qualified, which will cause type resolutions to fail.
-    #
-    # NOTE: This method is dynamically defined, see the source.
-    #
-    def column_definitions; end
+    def column_definitions(table_name)
+      return super unless is_chrono?(table_name)
 
-    define_method(:column_definitions) do |table_name|
-      return super(table_name) unless is_chrono?(table_name)
-
-      on_schema("#{TEMPORAL_SCHEMA},#{schema_search_path}", recurse: :ignore) { super(table_name) }
+      on_schema("#{TEMPORAL_SCHEMA},#{schema_search_path}", recurse: :ignore) { super }
     end
 
     # Evaluates the given block in the temporal schema.


### PR DESCRIPTION
Replace the dynamic define_method override with a direct method definition: def column_definitions(table_name).

All supported Rails versions define column_definitions(table_name) with this signature, so an explicit definition is safe and clearer.

Benefits:
- Improves readability and source discoverability (stack traces, blame).
- Keeps IDE/tooling accurate without a stub plus dynamic method.
- Removes a misleading comment about dynamic definition.

Behavior is unchanged: non-chrono tables still call super, and chrono tables still execute in "#{TEMPORAL_SCHEMA},#{schema_search_path}" to resolve types defined in other schemas.

Note: Other dynamically defined overrides remain where arity may vary across Rails versions.