### PR TITLE
Suppress postgres warning in specs

### DIFF
--- a/spec/chrono_model/adapter/base_spec.rb
+++ b/spec/chrono_model/adapter/base_spec.rb
@@ -69,14 +69,9 @@ RSpec.describe ChronoModel::Adapter do
         subject(:on_schema) do
           adapter.on_schema('test_1') do
             adapter.on_schema('test_2') do
-              adapter.execute 'BEGIN'
               adapter.execute 'ERRORING ON PURPOSE'
             end
           end
-        end
-
-        after do
-          adapter.execute 'ROLLBACK'
         end
 
         it {


### PR DESCRIPTION
Remove the internal `BEGIN` because the spec is already in a transaction
block.

This will prevent the following warnings:

```
WARNING: there is already a transaction in progress
WARNING: there is no transaction in progress
```