### PR TITLE
Fix PG::ExclusionViolation in concurrent updates

### DIFF
--- a/README.sql
+++ b/README.sql
@@ -111,10 +111,15 @@ create or replace function chronomodel_countries_update() returns trigger as $$
       return new;
     end if;
 
+    perform 1 from only temporal.countries where id = old.id for update;
+    if not found then
+      return null;
+    end if;
+
     _now := timezone('UTC', now());
     _hid := null;
 
-    select hid into _hid from history.countries where id = old.id and lower(validity) = _now;
+    select hid into _hid from history.countries where id = old.id and upper_inf(validity) and lower(validity) >= _now limit 1;
 
     if _hid is not null then
       update history.countries set ( name, updated_at ) = ( new.name, new.updated_at ) where hid = _hid;

--- a/lib/chrono_model/adapter/ddl.rb
+++ b/lib/chrono_model/adapter/ddl.rb
@@ -154,10 +154,15 @@ module ChronoModel
                         RETURN NEW;
                     END IF;
 
+                    PERFORM 1 FROM ONLY #{current} WHERE #{pk} = OLD.#{pk} FOR UPDATE;
+                    IF NOT FOUND THEN
+                        RETURN NULL;
+                    END IF;
+
                     _now := timezone('UTC', now());
                     _hid := NULL;
 
-                    #{"SELECT hid INTO _hid FROM #{history} WHERE #{pk} = OLD.#{pk} AND lower(validity) = _now;" unless ENV['CHRONOMODEL_NO_SQUASH']}
+                    #{"SELECT hid INTO _hid FROM #{history} WHERE #{pk} = OLD.#{pk} AND upper_inf(validity) AND lower(validity) >= _now LIMIT 1;" unless ENV['CHRONOMODEL_NO_SQUASH']}
 
                     IF _hid IS NOT NULL THEN
                         UPDATE #{history} SET (#{fields}) = (#{values}) WHERE hid = _hid;

--- a/spec/chrono_model/history_models_spec.rb
+++ b/spec/chrono_model/history_models_spec.rb
@@ -20,6 +20,9 @@ RSpec.describe ChronoModel do
       expected['sub_bars'] = SubBar::History  if defined?(SubBar::History)
       expected['sub_sub_bars'] = SubSubBar::History if defined?(SubSubBar::History)
 
+      expected['overlappers'] = Overlapper::History if defined?(Overlapper::History)
+      expected['overlap_bros'] = OverlapBro::History if defined?(OverlapBro::History)
+
       # default_scope_spec
       expected['defoos']   = Defoo::History   if defined?(Defoo::History)
 

--- a/spec/chrono_model/time_machine/concurrency_spec.rb
+++ b/spec/chrono_model/time_machine/concurrency_spec.rb
@@ -1,0 +1,198 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'support/time_machine/structure'
+
+RSpec.describe ChronoModel::TimeMachine do
+  include ChronoTest::TimeMachine::Helpers
+
+  describe 'concurrent updates' do
+    it 'handles concurrent updates without PG::ExclusionViolation' do
+      foo = Foo.create!(name: 'concurrency-test')
+
+      threads_count = 4
+      iterations = 10
+      errors = []
+      mutex = Mutex.new
+
+      threads = Array.new(threads_count) do |i|
+        Thread.new do
+          Foo.connection_pool.with_connection do
+            iterations.times do |j|
+              Foo.transaction do
+                record = Foo.find(foo.id)
+                record.update!(name: "iteration-#{i}-#{j}")
+              end
+            rescue StandardError => e
+              mutex.synchronize do
+                errors << "Thread #{i} Iteration #{j}: #{e.class} - #{e.message}"
+              end
+            end
+          end
+        end
+      end
+
+      threads.each(&:join)
+
+      expect(errors).to be_empty
+    ensure
+      # Clean up: delete the record and its history
+      if foo
+        foo.destroy
+        Foo::History.where(id: foo.id).delete_all
+      end
+    end
+
+    it 'keeps the open history row aligned with the current row when an older transaction commits last' do
+      foo = Foo.create!(name: 'orig')
+      errors = []
+      mutex = Mutex.new
+      started = Queue.new
+      proceed = Queue.new
+      stale = nil
+      stale_started = false
+
+      begin
+        stale = Thread.new do
+          Foo.connection_pool.with_connection do
+            Foo.transaction do
+              Foo.connection.execute("SELECT timezone('UTC', now())")
+              stale_started = true
+              started << true
+              proceed.pop
+              Foo.find(foo.id).update!(name: 'stale')
+            end
+          end
+        rescue StandardError => e
+          started << true unless stale_started
+          mutex.synchronize { errors << e }
+        end
+
+        started.pop
+        sleep(0.05)
+        Foo.find(foo.id).update!(name: 't1')
+        sleep(0.05)
+        Foo.find(foo.id).update!(name: 't2')
+
+        proceed << true
+        stale.join
+
+        expect(errors).to be_empty
+        expect(foo.reload.name).to eq('stale')
+        expect(Foo::History.where(id: foo.id).where('upper_inf(validity)').pick(:name)).to eq(foo.name)
+      ensure
+        proceed << true if proceed && stale&.alive?
+        stale&.join
+
+        if foo
+          Foo.where(id: foo.id).delete_all
+          Foo::History.where(id: foo.id).delete_all
+        end
+      end
+    end
+
+    it 'suppresses a stale update when the current row is deleted while waiting for the lock' do
+      foo = Foo.create!(name: 'delete-race')
+      errors = []
+      mutex = Mutex.new
+      deleted = Queue.new
+      commit = Queue.new
+      updater_pid = Queue.new
+      updated = nil
+      deleter = nil
+      updater = nil
+
+      begin
+        deleter = Thread.new do
+          Foo.connection_pool.with_connection do
+            Foo.transaction do
+              Foo.where(id: foo.id).delete_all
+              deleted << true
+              commit.pop
+            end
+          end
+        rescue StandardError => e
+          deleted << true
+          mutex.synchronize { errors << e }
+        end
+
+        deleted.pop
+
+        updater = Thread.new do
+          Foo.connection_pool.with_connection do |connection|
+            updater_pid << connection.select_value('SELECT pg_backend_pid()')
+            updated = connection.update("UPDATE foos SET name = 'stale' WHERE id = #{Integer(foo.id)}")
+          end
+        rescue StandardError => e
+          updater_pid << nil
+          mutex.synchronize { errors << e }
+        end
+
+        pid = updater_pid.pop
+        deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 5
+        loop do
+          wait_event = Foo.connection.select_value(<<~SQL.squish)
+            SELECT wait_event_type FROM pg_stat_activity WHERE pid = #{Integer(pid)}
+          SQL
+          break if wait_event == 'Lock'
+
+          if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+            raise 'stale update did not wait for the current-row lock'
+          end
+
+          sleep 0.01
+        end
+
+        commit << true
+        deleter.join
+        updater.join
+
+        expect(errors).to be_empty
+        expect(updated).to eq(0)
+        expect(Foo.exists?(foo.id)).to be(false)
+        expect(Foo::History.where(id: foo.id).where('upper_inf(validity)').count).to eq(0)
+      ensure
+        commit << true if deleter&.alive?
+        deleter&.join
+        updater&.join
+
+        Foo.where(id: foo.id).delete_all if foo
+        Foo::History.where(id: foo.id).delete_all if foo
+      end
+    end
+  end
+
+  describe 'concurrent deletions' do
+    it 'handles concurrent deletions without error' do
+      threads_count = 4
+      foo_ids = Array.new(threads_count) { |i| Foo.create!(name: "test-delete-#{i}") }.map(&:id)
+      errors = []
+      mutex = Mutex.new
+
+      threads = Array.new(threads_count) do |i|
+        Thread.new do
+          Foo.connection_pool.with_connection do
+            Foo.where(id: foo_ids[i]).delete_all
+          end
+        rescue StandardError => e
+          mutex.synchronize do
+            errors << "Thread #{i}: #{e.class} - #{e.message}"
+          end
+        end
+      end
+
+      threads.each(&:join)
+
+      expect(errors).to be_empty
+      foo_ids.each do |id|
+        expect(Foo.exists?(id)).to be(false)
+      end
+    ensure
+      # Clean up any remaining records and history
+      foo_ids&.each do |id|
+        Foo::History.where(id: id).delete_all
+        Foo.where(id: id).delete_all
+      end
+    end
+  end
+end

--- a/spec/chrono_model/time_machine/transaction_timestamp_spec.rb
+++ b/spec/chrono_model/time_machine/transaction_timestamp_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'support/time_machine/structure'
+
+RSpec.describe ChronoModel::TimeMachine do
+  include ChronoTest::TimeMachine::Helpers
+
+  after do
+    Overlapper::History.delete_all
+    Overlapper.delete_all
+    OverlapBro::History.delete_all
+    OverlapBro.delete_all
+  end
+
+  describe 'records created in the same transaction' do
+    it 'are all visible in as_of() queries using the first record creation time' do
+      first_record = nil
+      second_record = nil
+      third_record = nil
+
+      Overlapper.transaction do
+        first_record = Overlapper.create!(name: 'first')
+        second_record = Overlapper.create!(name: 'second')
+        third_record = Overlapper.create!(name: 'third')
+      end
+
+      # Get the validity start time of the first record from history
+      first_record_validity_start = first_record.history.last.validity.begin
+
+      # All records created in the same transaction should be visible
+      # when querying as_of() with the first record's creation timestamp
+      records_at_first_timestamp = Overlapper.as_of(first_record_validity_start)
+      expect(records_at_first_timestamp.map(&:id)).to contain_exactly(first_record.id, second_record.id, third_record.id)
+    end
+
+    it 'allows querying associated records created in the same transaction' do
+      overlap = nil
+
+      Overlapper.transaction do
+        bro = OverlapBro.create!(name: 'bro record')
+        overlap = Overlapper.create!(name: 'child', overlap_bro: bro)
+      end
+
+      overlap_validity_start = overlap.history.last.validity.begin
+      overlap_at_creation = Overlapper.as_of(overlap_validity_start).find(overlap.id)
+      # Child record should be visible through the association
+      expect(overlap_at_creation.overlap_bro.name).to eq('bro record')
+    end
+
+    it 'maintains consistent timestamps for records created together' do
+      records = nil
+
+      Overlapper.transaction do
+        records = Array.new(5) { |i| Overlapper.create!(name: "record-#{i}") }
+      end
+
+      # All records should have the same validity start time (transaction time)
+      validity_starts = records.map { |r| r.history.last.validity.begin }
+
+      expect(validity_starts.uniq.size).to eq(1),
+                                           "Expected all records to have the same validity start time, but got: #{validity_starts.inspect}"
+    end
+  end
+
+  describe 'records updated in the same transaction' do
+    it 'keeps updates visible at the transaction timestamp' do
+      bro = nil
+
+      OverlapBro.transaction do
+        bro = OverlapBro.create!(name: 'bro_v1')
+        3.times do |i|
+          overlap = Overlapper.create!(name: "overlapper_#{i}", overlap_bro: bro)
+          overlap.update!(name: "overlapper_#{i}_updated")
+        end
+      end
+
+      overlappers_at_bro_time = Overlapper.as_of(bro.history.last.validity.begin).where(overlap_bro_id: bro.id)
+
+      expect(overlappers_at_bro_time.map(&:name)).to contain_exactly(
+        'overlapper_0_updated',
+        'overlapper_1_updated',
+        'overlapper_2_updated'
+      )
+    end
+  end
+
+  describe 'records updated after initial creation' do
+    it 'handles updates without timestamp conflicts' do
+      overlap = Overlapper.create!(name: 'original')
+
+      # Sleep a tiny bit to ensure different transaction time
+      sleep(0.01)
+
+      overlap.update!(name: 'updated')
+
+      # The update should succeed and create a valid history entry
+      overlap.reload
+      expect(overlap.name).to eq('updated')
+
+      # History should have entries with non-overlapping validity ranges
+      history_entries = overlap.history.order(:hid)
+      expect(history_entries.size).to eq 2
+    end
+  end
+end

--- a/spec/support/time_machine/structure.rb
+++ b/spec/support/time_machine/structure.rb
@@ -83,6 +83,16 @@ module ChronoTest
       t.references :sub_bar
     end
 
+    adapter.create_table 'overlap_bros', temporal: true do |t|
+      t.string :name
+    end
+
+    adapter.create_table 'overlappers', temporal: true do |t|
+      t.string :name
+
+      t.references :overlap_bro
+    end
+
     class ::Bar < ActiveRecord::Base
       include ChronoModel::TimeMachine
 
@@ -160,6 +170,18 @@ module ChronoTest
       include ChronoModel::TimeMachine
 
       belongs_to :sub_bar
+    end
+
+    class ::OverlapBro < ActiveRecord::Base
+      include ChronoModel::TimeMachine
+
+      has_many :overlappers
+    end
+
+    class ::Overlapper < ActiveRecord::Base
+      include ChronoModel::TimeMachine
+
+      belongs_to :overlap_bro, optional: true
     end
 
     # Master timeline, used in multiple specs. It is defined here


### PR DESCRIPTION
This PR addresses concurrency issues where simultaneous updates to the same record could trigger a PG::ExclusionViolation due to overlapping validity ranges.

## Key Changes & Technical Details:

Fix `PG::ExclusionViolation`:

Added explicit row locking (`PERFORM 1 ... FOR UPDATE`) in the UPDATE trigger. This serializes concurrent updates to the same row, preventing them from attempting to insert overlapping history ranges simultaneously.

After adding the lock we have the second issue with `RangeError`, we can fix it with slightly updated squashing logic.

Update Squashing Logic:
I updated the query that detects multiple updates for the same transaction and changed conditions from `lower(validity) = _now` to `lower(validity) >= _now` and added `upper_inf(validity)` for find only open-ended ranges. We can have only one open range by system design.

This means that when the `validity` is already updated in a parallel transaction that runs at the same millisecond, we will squash the changes and not create a new historical record.