### PR TITLE
Disable Style/OneClassPerFile for specs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -97,3 +97,8 @@ Style/HashExcept:
 
 Style/IfUnlessModifier:
   Enabled: false
+
+Style/OneClassPerFile:
+  Exclude:
+    - 'benchmarks/**/*'
+    - 'spec/**/*'


### PR DESCRIPTION
RSpec files commonly define multiple top-level classes and modules (test subjects, helpers, shared contexts), making this cop impractical and noisy in the spec directory.