### PR TITLE
Fix new RuboCop offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -70,6 +70,10 @@ Rails/SkipsModelValidations:
 Rails/TimeZone:
   Enabled: false
 
+RSpec/ExpectActual:
+  Exclude:
+    - 'spec/aruba/**/*'
+
 RSpec/ExampleLength:
   Enabled: false
 

--- a/spec/chrono_model/time_machine/history_spec.rb
+++ b/spec/chrono_model/time_machine/history_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe ChronoModel::TimeMachine do
     end
 
     describe 'does not add as_of_time when there are aggregates' do
-      it { expect($t.foo.history.select('max(id)').to_sql).not_to match(/as_of_time/) }
+      it { expect($t.foo.history.select('max(id)').to_sql).not_to include('as_of_time') }
 
       it {
         expect($t.foo.history.reorder('id').select('max(id) as foo, min(id) as bar').group('id').first.attributes.keys).to match_array %w[hid foo


### PR DESCRIPTION
- Autofix safe RSpec/MatchWithSimpleRegex offense
- Disable `RSpec/ExpectActual` in aruba specs to allow predicates like `be_an_existing_file`